### PR TITLE
feat: add TYPO3 scheduler runner for feature branch instances

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -2,7 +2,9 @@
 	"symbol-whitelist": [
 		"Normalizer",
 		"after",
+		"askConfirmation",
 		"before",
+		"checkVerbosity",
 		"commandSupportSubcommand",
 		"debug",
 		"Deployer\\askHiddenResponse",
@@ -17,12 +19,15 @@
 		"Deployer\\test",
 		"Deployer\\upload",
 		"get",
+		"has",
+		"info",
+		"isUrlShortener",
 		"parse",
 		"runExtended",
 		"runLocally",
 		"set",
 		"task",
 		"test",
-		"has"
+		"uploadTemplate"
 	]
 }

--- a/deployer/feature/task/feature_sync.php
+++ b/deployer/feature/task/feature_sync.php
@@ -60,6 +60,18 @@ function waitForDatabaseHost(): void
  * Resolves the database hostname to its IP address and replaces it in the shared .env file.
  * This eliminates DNS dependency for all subsequent remote commands (TYPO3 CLI, etc.),
  * working around DNS flapping for newly created databases on Mittwald infrastructure.
+ *
+ * Background: After Mittwald creates a new database, the DNS entry for the host
+ * (e.g. mysql-xyz.pg-s-xxx.db.project.host) is intermittently resolvable for several
+ * minutes - it resolves, then fails, then resolves again. A TCP connectivity check
+ * passing does not guarantee that the next process can resolve the hostname seconds later.
+ * By resolving the hostname to its IP once and writing the IP to .env, all subsequent
+ * commands (db_sync_tool, typo3 database:updateschema, etc.) bypass DNS entirely.
+ *
+ * This workaround can be removed if Mittwald provides a stable DNS propagation status
+ * via their API or resolves the underlying DNS flapping issue.
+ *
+ * @see MittwaldApi::checkDatabaseHostReachable() for the initial TCP connectivity check
  */
 function resolveDatabaseHostToIp(string $hostname): void
 {

--- a/deployer/typo3/autoload.php
+++ b/deployer/typo3/autoload.php
@@ -19,3 +19,4 @@ require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/deployer/typo3/
 require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/deployer/typo3/task/deploy_database.php');
 require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/deployer/typo3/task/deploy_setup.php');
 require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/deployer/typo3/task/cache_warmup.php');
+require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/deployer/typo3/task/feature_scheduler.php');

--- a/deployer/typo3/dist/scheduler.sh.dist
+++ b/deployer/typo3/dist/scheduler.sh.dist
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# TYPO3 Scheduler Runner for Feature Branch Deployment
+# Runs the TYPO3 scheduler for all active feature branch instances.
+#
+# Crontab example:
+#   */5 * * * * {{SCHEDULER_PATH}} >> {{LOG_PATH}} 2>&1
+#
+
+set -o pipefail
+
+INSTANCES_DIR="{{INSTANCES_DIR}}"
+TYPO3_BIN="{{TYPO3_BIN}}"
+PHP_BIN="{{PHP_BIN}}"
+
+# validate template substitution
+if [[ "$INSTANCES_DIR" == *"{{"* ]] || [[ "$TYPO3_BIN" == *"{{"* ]] || [[ "$PHP_BIN" == *"{{"* ]]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: Template substitution failed — unreplaced placeholders detected" >&2
+    exit 1
+fi
+
+executed=0
+failed=0
+
+for instance_dir in "$INSTANCES_DIR"/*/; do
+    [ -d "$instance_dir" ] || continue
+
+    # skip hidden directories (e.g. .fbd)
+    instance_name=$(basename "$instance_dir")
+    [[ "$instance_name" == .* ]] && continue
+
+    current_dir="${instance_dir}current"
+    [ -d "$current_dir" ] || continue
+
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Running scheduler for: $instance_name"
+
+    (cd "$current_dir" && "$PHP_BIN" "$TYPO3_BIN" scheduler:run 2>&1)
+    exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] OK: Scheduler completed for: $instance_name"
+        executed=$((executed + 1))
+    else
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: Scheduler failed for $instance_name (exit code: $exit_code)"
+        failed=$((failed + 1))
+    fi
+done
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Scheduler completed: $executed succeeded, $failed failed"

--- a/deployer/typo3/task/feature_scheduler.php
+++ b/deployer/typo3/task/feature_scheduler.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Deployer;
+
+task('feature:scheduler', function () {
+
+    checkVerbosity();
+
+    $deployPath = get('deploy_path');
+    $featureDirectoryPath = rtrim(get('feature_directory_path'), '/');
+    $schedulerPath = $deployPath . '/' . $featureDirectoryPath . '/scheduler.sh';
+    $logPath = $deployPath . '/' . $featureDirectoryPath . '/scheduler.log';
+
+    $upload = true;
+    if (test("[[ -f $schedulerPath ]]")) {
+        $upload = askConfirmation("A scheduler.sh file already exists: " . $schedulerPath . " \n Do you really want to override the file?", true);
+    }
+
+    if (!$upload) return;
+
+    // without url shortener, feature instances are direct subdirectories of deploy_path
+    // with url shortener, they reside in the instances/ subdirectory
+    $instancesDir = isUrlShortener()
+        ? $deployPath . '/' . get('feature_url_shortener_path')
+        : $deployPath;
+
+    $phpBin = has('bin/php') ? get('bin/php') : 'php';
+
+    $arguments = [
+        'SCHEDULER_PATH' => $schedulerPath,
+        'LOG_PATH' => $logPath,
+        'INSTANCES_DIR' => $instancesDir,
+        'TYPO3_BIN' => get('bin/typo3cms'),
+        'PHP_BIN' => $phpBin,
+    ];
+
+    uploadTemplate(
+        __DIR__ . '/../dist/scheduler.sh.dist',
+        '/' . $featureDirectoryPath . '/scheduler.sh',
+        $arguments
+    );
+
+    runExtended("chmod +x $schedulerPath");
+
+    info("Scheduler script uploaded to <fg=magenta;options=bold>$schedulerPath</>");
+    info("Crontab: <fg=cyan>*/5 * * * * $schedulerPath >> $logPath 2>&1</>");
+
+})
+    ->select('type=feature-branch-deployment')
+    ->desc('Upload TYPO3 scheduler script for all feature branch instances')
+;

--- a/docs/FEATURE.md
+++ b/docs/FEATURE.md
@@ -9,6 +9,7 @@ The feature branch deployment describes the deployment and initialization proces
 + [Synchronization](#synchronization)
 + [Information](#information)
 + [Pathing](#pathing)
++ [Scheduler](#scheduler)
 + [Cleanup](#cleanup)
 + [Further more](#further-more)
 + [FAQ](#faq)
@@ -208,6 +209,33 @@ The folder structure on the server will look like this:
 ```
 
 So the resulting url will look like: `https://test.local/app`.
+
+### Scheduler
+
+The `feature:scheduler` command uploads a standalone bash script to the target server, which runs the TYPO3 scheduler for all active feature branch instances. This is useful for executing periodic tasks (e.g. search indexing, mail queue processing) across all feature branches.
+
+```bash
+$ vendor/bin/dep feature:scheduler stage
+```
+
+The script is uploaded to the `.fbd/` directory on the target server:
+
+```bash
+├── .fbd/
+│   ├── scheduler.sh
+│   ├── scheduler.log
+│   └── ...
+```
+
+On the target server, add a crontab entry to run the scheduler periodically:
+
+```bash
+*/5 * * * * /var/www/html/.fbd/scheduler.sh >> /var/www/html/.fbd/scheduler.log 2>&1
+```
+
+The script requires no additional dependencies on the target system beyond what is already present for running TYPO3 (bash, PHP CLI). The paths for the PHP binary and the TYPO3 CLI are resolved from the deployer configuration (`bin/php`, `bin/typo3cms`) during upload.
+
+The script automatically discovers all feature branch instances, skips instances without a current release and continues execution if the scheduler fails for a single instance.
 
 ### Cleanup
 


### PR DESCRIPTION
## Summary

- Add standalone bash script that runs the TYPO3 scheduler (`scheduler:run`) for all active feature branch instances on the target server
- Add `feature:scheduler` deployer task to template and upload the script
- No additional dependencies required on the target system beyond bash and PHP CLI

## Changes

- `deployer/typo3/dist/scheduler.sh.dist` - Bash script template with placeholder substitution for PHP binary, TYPO3 CLI and instance paths
- `deployer/typo3/task/feature_scheduler.php` - Deployer task that resolves config values and uploads the script via `uploadTemplate()`
- `deployer/typo3/autoload.php` - Register the new task in the autoload chain
- `docs/FEATURE.md` - Document the scheduler section with usage and crontab example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scheduler deployment task that creates and deploys a runnable scheduler script, sets permissions, and logs installation steps

* **Documentation**
  * Added Scheduler section with usage examples, file layout, and crontab integration (duplicate insertion present)

* **Style**
  * Expanded inline documentation/comments clarifying behavior and operational notes

* **Chores**
  * Updated runtime autoload inclusion and adjusted whitelist of public symbols
<!-- end of auto-generated comment: release notes by coderabbit.ai -->