### PR TITLE
feat: add server requirements check module

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -36,6 +36,20 @@ require_once(__DIR__ . '/deployer/security/config/options.php');
 require_once(__DIR__ . '/deployer/security/task/security.php');
 
 /*
+ * requirements
+ */
+require_once(__DIR__ . '/deployer/requirements/functions.php');
+require_once(__DIR__ . '/deployer/requirements/config/set.php');
+require_once(__DIR__ . '/deployer/requirements/task/requirements.php');
+require_once(__DIR__ . '/deployer/requirements/task/check_locales.php');
+require_once(__DIR__ . '/deployer/requirements/task/check_packages.php');
+require_once(__DIR__ . '/deployer/requirements/task/check_php_extensions.php');
+require_once(__DIR__ . '/deployer/requirements/task/check_php_settings.php');
+require_once(__DIR__ . '/deployer/requirements/task/check_database.php');
+require_once(__DIR__ . '/deployer/requirements/task/check_user.php');
+require_once(__DIR__ . '/deployer/requirements/task/check_env.php');
+
+/*
  * dev
  */
 require_once(__DIR__ . '/deployer/dev/functions.php');

--- a/deployer/requirements/config/set.php
+++ b/deployer/requirements/config/set.php
@@ -78,7 +78,8 @@ set('requirements_php_settings', [
 ]);
 
 // Database
-set('requirements_db_min_version', '10.2.7');
+set('requirements_mariadb_min_version', '10.2.7');
+set('requirements_mysql_min_version', '8.0.0');
 
 // User / permissions
 set('requirements_user_group', 'www-data');

--- a/deployer/requirements/config/set.php
+++ b/deployer/requirements/config/set.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+// Accumulator
+set('requirements_rows', []);
+
+// Enable/disable per check category
+set('requirements_check_locales_enabled', true);
+set('requirements_check_packages_enabled', true);
+set('requirements_check_php_extensions_enabled', true);
+set('requirements_check_php_settings_enabled', true);
+set('requirements_check_database_enabled', true);
+set('requirements_check_user_enabled', true);
+set('requirements_check_env_enabled', true);
+
+// Locales
+set('requirements_locales', ['de_DE.utf8', 'en_US.utf8']);
+
+// System packages (display name => CLI command)
+set('requirements_packages', [
+    'rsync' => 'rsync',
+    'curl' => 'curl',
+    'graphicsmagick' => 'gm',
+    'ghostscript' => 'gs',
+    'git' => 'git',
+    'gzip' => 'gzip',
+    'mariadb-client' => 'mysql',
+    'unzip' => 'unzip',
+    'patch' => 'patch',
+    'exiftool' => 'exiftool',
+    'composer' => 'composer',
+]);
+
+// PHP extensions (framework-aware)
+set('requirements_php_extensions', function (): array {
+    if (has('app_type') && get('app_type') === 'typo3') {
+        return [
+            'curl',
+            'gd',
+            'mbstring',
+            'soap',
+            'xml',
+            'zip',
+            'intl',
+            'apcu',
+            'pdo',
+            'pdo_mysql',
+            'json',
+            'fileinfo',
+            'openssl',
+        ];
+    }
+
+    return [
+        'curl',
+        'gd',
+        'mbstring',
+        'xml',
+        'zip',
+        'intl',
+        'pdo',
+        'pdo_mysql',
+    ];
+});
+
+// PHP settings
+set('requirements_php_settings', [
+    'max_execution_time' => '240',
+    'memory_limit' => '512M',
+    'max_input_vars' => '1500',
+    'date.timezone' => 'Europe/Berlin',
+    'post_max_size' => '31M',
+    'upload_max_filesize' => '30M',
+    'opcache.memory_consumption' => '256',
+]);
+
+// Database
+set('requirements_db_min_version', '10.2.7');
+
+// User / permissions
+set('requirements_user_group', 'www-data');
+set('requirements_deploy_path_permissions', '2770');
+
+// Env file
+set('requirements_env_file', '.env');
+set('requirements_env_vars', function (): array {
+    if (has('app_type') && get('app_type') === 'typo3') {
+        return [
+            'TYPO3_CONF_VARS__DB__Connections__Default__host',
+            'TYPO3_CONF_VARS__DB__Connections__Default__dbname',
+            'TYPO3_CONF_VARS__DB__Connections__Default__user',
+            'TYPO3_CONF_VARS__DB__Connections__Default__password',
+        ];
+    }
+
+    return [];
+});

--- a/deployer/requirements/functions.php
+++ b/deployer/requirements/functions.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use Symfony\Component\Console\Helper\Table;
+
+const REQUIREMENT_OK = 'OK';
+const REQUIREMENT_WARN = 'WARN';
+const REQUIREMENT_FAIL = 'FAIL';
+const REQUIREMENT_SKIP = 'SKIP';
+
+/**
+ * PHP byte-based settings compared with >= after converting to bytes.
+ *
+ * @see parsePhpBytes()
+ */
+const REQUIREMENT_BYTE_SETTINGS = [
+    'memory_limit',
+    'post_max_size',
+    'upload_max_filesize',
+];
+
+/**
+ * PHP numeric settings compared with >= as integers.
+ */
+const REQUIREMENT_NUMERIC_SETTINGS = [
+    'max_execution_time',
+    'max_input_vars',
+    'opcache.memory_consumption',
+];
+
+function addRequirementRow(string $check, string $status, string $info = ''): void
+{
+    $rows = get('requirements_rows');
+    $rows[] = [
+        'check' => $check,
+        'status' => $status,
+        'info' => $info,
+    ];
+    set('requirements_rows', $rows);
+}
+
+function formatRequirementStatus(string $status): string
+{
+    return match ($status) {
+        REQUIREMENT_OK => '<fg=green>[OK]</>',
+        REQUIREMENT_WARN => '<fg=yellow>[WARN]</>',
+        REQUIREMENT_FAIL => '<fg=red>[FAIL]</>',
+        REQUIREMENT_SKIP => '<fg=gray>[SKIP]</>',
+        default => "[$status]",
+    };
+}
+
+function renderRequirementsTable(): void
+{
+    $rows = get('requirements_rows');
+
+    $tableRows = array_map(
+        static fn(array $row): array => [
+            $row['check'],
+            formatRequirementStatus($row['status']),
+            $row['info'],
+        ],
+        $rows
+    );
+
+    $hostAlias = currentHost()->getAlias();
+
+    (new Table(output()))
+        ->setHeaderTitle("Server Requirements ($hostAlias)")
+        ->setHeaders(['Check', 'Status', 'Info'])
+        ->setRows($tableRows)
+        ->render();
+
+    $counts = array_count_values(array_column($rows, 'status'));
+    $ok = $counts[REQUIREMENT_OK] ?? 0;
+    $fail = $counts[REQUIREMENT_FAIL] ?? 0;
+    $warn = $counts[REQUIREMENT_WARN] ?? 0;
+    $skip = $counts[REQUIREMENT_SKIP] ?? 0;
+
+    writeln('');
+    writeln(sprintf(
+        '<fg=green>%d passed</>, <fg=red>%d failed</>, <fg=yellow>%d warnings</>, <fg=gray>%d skipped</>',
+        $ok,
+        $fail,
+        $warn,
+        $skip
+    ));
+}
+
+function parsePhpBytes(string $value): int
+{
+    $value = trim($value);
+
+    if ($value === '-1') {
+        return -1;
+    }
+
+    $unit = strtoupper(substr($value, -1));
+    $numericValue = (int) $value;
+
+    return match ($unit) {
+        'G' => $numericValue * 1073741824,
+        'M' => $numericValue * 1048576,
+        'K' => $numericValue * 1024,
+        default => $numericValue,
+    };
+}
+
+function meetsPhpRequirement(string $actual, string $expected, string $setting): bool
+{
+    if (in_array($setting, REQUIREMENT_BYTE_SETTINGS, true)) {
+        $actualBytes = parsePhpBytes($actual);
+        $expectedBytes = parsePhpBytes($expected);
+
+        if ($actualBytes === -1) {
+            return true;
+        }
+
+        if ($expectedBytes === -1) {
+            return false;
+        }
+
+        return $actualBytes >= $expectedBytes;
+    }
+
+    if (in_array($setting, REQUIREMENT_NUMERIC_SETTINGS, true)) {
+        $actualInt = (int) $actual;
+        $expectedInt = (int) $expected;
+
+        if ($setting === 'max_execution_time' && $actualInt === 0) {
+            return true;
+        }
+
+        return $actualInt >= $expectedInt;
+    }
+
+    return $actual === $expected;
+}
+
+/**
+ * @return array<string, string>
+ */
+function getSharedEnvVars(): array
+{
+    $envFile = get('requirements_env_file');
+    $envPath = get('deploy_path') . '/shared/' . $envFile;
+
+    if (!test("[ -f $envPath ]")) {
+        return [];
+    }
+
+    $content = run("cat $envPath");
+    $lines = array_filter(explode("\n", $content));
+    $vars = [];
+
+    foreach ($lines as $line) {
+        $line = trim($line);
+
+        if ($line === '' || str_starts_with($line, '#')) {
+            continue;
+        }
+
+        $parts = explode('=', $line, 2);
+
+        if (count($parts) < 2) {
+            continue;
+        }
+
+        $value = trim($parts[1]);
+
+        if ((str_starts_with($value, '"') && str_ends_with($value, '"'))
+            || (str_starts_with($value, "'") && str_ends_with($value, "'"))) {
+            $value = substr($value, 1, -1);
+        }
+
+        $vars[trim($parts[0])] = $value;
+    }
+
+    return $vars;
+}

--- a/deployer/requirements/functions.php
+++ b/deployer/requirements/functions.php
@@ -176,7 +176,8 @@ function getSharedEnvVars(): array
             $value = substr($value, 1, -1);
         }
 
-        $vars[trim($parts[0])] = $value;
+        $key = trim(preg_replace('/^export\s+/', '', trim($parts[0])));
+        $vars[$key] = $value;
     }
 
     return $vars;

--- a/deployer/requirements/task/check_database.php
+++ b/deployer/requirements/task/check_database.php
@@ -35,13 +35,21 @@ task('requirements:check:database', function (): void {
         return;
     }
 
-    $minVersion = get('requirements_db_min_version');
-
-    if (preg_match('/Distrib\s+([\d.]+)/', $versionOutput, $matches)
-        || preg_match('/Ver\s+([\d.]+)/', $versionOutput, $matches)) {
+    if (preg_match('/Distrib\s+([\d.]+)/', $versionOutput, $matches)) {
         $actualVersion = $matches[1];
+        $minVersion = get('requirements_mariadb_min_version');
         $meets = version_compare($actualVersion, $minVersion, '>=');
-        $info = $meets ? $actualVersion : "$actualVersion (required: >= $minVersion)";
+        $info = $meets ? "MariaDB $actualVersion" : "MariaDB $actualVersion (required: >= $minVersion)";
+        addRequirementRow(
+            'Database client',
+            $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL,
+            $info
+        );
+    } elseif (preg_match('/Ver\s+([\d.]+)/', $versionOutput, $matches)) {
+        $actualVersion = $matches[1];
+        $minVersion = get('requirements_mysql_min_version');
+        $meets = version_compare($actualVersion, $minVersion, '>=');
+        $info = $meets ? "MySQL $actualVersion" : "MySQL $actualVersion (required: >= $minVersion)";
         addRequirementRow(
             'Database client',
             $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL,

--- a/deployer/requirements/task/check_database.php
+++ b/deployer/requirements/task/check_database.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use Deployer\Exception\RunException;
+
+task('requirements:check:database', function (): void {
+    if (!get('requirements_check_database_enabled')) {
+        return;
+    }
+
+    // Try mariadb command first (newer MariaDB installations), then fall back to mysql
+    $versionOutput = '';
+    $clientFound = false;
+
+    foreach (['mariadb', 'mysql'] as $command) {
+        try {
+            $versionOutput = trim(run("$command --version 2>/dev/null"));
+
+            if ($versionOutput !== '') {
+                $clientFound = true;
+
+                break;
+            }
+        } catch (RunException) {
+            continue;
+        }
+    }
+
+    if (!$clientFound) {
+        addRequirementRow('Database client', REQUIREMENT_SKIP, 'Neither mariadb nor mysql command available');
+
+        return;
+    }
+
+    $minVersion = get('requirements_db_min_version');
+
+    if (preg_match('/Distrib\s+([\d.]+)/', $versionOutput, $matches)
+        || preg_match('/Ver\s+([\d.]+)/', $versionOutput, $matches)) {
+        $actualVersion = $matches[1];
+        $meets = version_compare($actualVersion, $minVersion, '>=');
+        $info = $meets ? $actualVersion : "$actualVersion (required: >= $minVersion)";
+        addRequirementRow(
+            'Database client',
+            $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL,
+            $info
+        );
+    } else {
+        addRequirementRow('Database client', REQUIREMENT_WARN, "Could not parse version: $versionOutput");
+    }
+})->hidden();

--- a/deployer/requirements/task/check_env.php
+++ b/deployer/requirements/task/check_env.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+task('requirements:check:env', function (): void {
+    if (!get('requirements_check_env_enabled')) {
+        return;
+    }
+
+    $envFile = get('requirements_env_file');
+    $envPath = get('deploy_path') . '/shared/' . $envFile;
+    $requiredVars = get('requirements_env_vars');
+
+    // Check if shared .env exists
+    if (!test("[ -f $envPath ]")) {
+        addRequirementRow(
+            "Env file: $envFile",
+            REQUIREMENT_WARN,
+            "Not found at shared/$envFile"
+        );
+
+        foreach ($requiredVars as $var) {
+            addRequirementRow("Env var: $var", REQUIREMENT_SKIP, 'Env file not available');
+        }
+
+        return;
+    }
+
+    addRequirementRow("Env file: $envFile", REQUIREMENT_OK, "Exists at shared/$envFile");
+
+    if (empty($requiredVars)) {
+        return;
+    }
+
+    // Check required env variables
+    $envVars = getSharedEnvVars();
+
+    foreach ($requiredVars as $var) {
+        if (array_key_exists($var, $envVars) && $envVars[$var] !== '') {
+            addRequirementRow("Env var: $var", REQUIREMENT_OK, 'Set');
+        } elseif (array_key_exists($var, $envVars)) {
+            addRequirementRow("Env var: $var", REQUIREMENT_WARN, 'Set but empty');
+        } else {
+            addRequirementRow("Env var: $var", REQUIREMENT_FAIL, 'Missing');
+        }
+    }
+})->hidden();

--- a/deployer/requirements/task/check_locales.php
+++ b/deployer/requirements/task/check_locales.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use Deployer\Exception\RunException;
+
+task('requirements:check:locales', function (): void {
+    if (!get('requirements_check_locales_enabled')) {
+        return;
+    }
+
+    try {
+        $availableLocales = strtolower(run('locale -a 2>/dev/null'));
+    } catch (RunException) {
+        addRequirementRow('Locales', REQUIREMENT_SKIP, 'Could not retrieve locale list');
+
+        return;
+    }
+
+    foreach (get('requirements_locales') as $locale) {
+        $normalizedLocale = strtolower($locale);
+        $altLocale = str_replace('.utf8', '.utf-8', $normalizedLocale);
+
+        if (str_contains($availableLocales, $normalizedLocale)
+            || str_contains($availableLocales, $altLocale)) {
+            addRequirementRow("Locale: $locale", REQUIREMENT_OK, 'Available');
+        } else {
+            addRequirementRow("Locale: $locale", REQUIREMENT_FAIL, 'Not available');
+        }
+    }
+})->hidden();

--- a/deployer/requirements/task/check_locales.php
+++ b/deployer/requirements/task/check_locales.php
@@ -19,12 +19,16 @@ task('requirements:check:locales', function (): void {
         return;
     }
 
+    $localeLines = array_map('trim', explode("\n", $availableLocales));
+
     foreach (get('requirements_locales') as $locale) {
         $normalizedLocale = strtolower($locale);
         $altLocale = str_replace('.utf8', '.utf-8', $normalizedLocale);
 
-        if (str_contains($availableLocales, $normalizedLocale)
-            || str_contains($availableLocales, $altLocale)) {
+        $found = in_array($normalizedLocale, $localeLines, true)
+            || in_array($altLocale, $localeLines, true);
+
+        if ($found) {
             addRequirementRow("Locale: $locale", REQUIREMENT_OK, 'Available');
         } else {
             addRequirementRow("Locale: $locale", REQUIREMENT_FAIL, 'Not available');

--- a/deployer/requirements/task/check_packages.php
+++ b/deployer/requirements/task/check_packages.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use Deployer\Exception\RunException;
+
+task('requirements:check:packages', function (): void {
+    if (!get('requirements_check_packages_enabled')) {
+        return;
+    }
+
+    foreach (get('requirements_packages') as $displayName => $command) {
+        if (is_int($displayName)) {
+            $displayName = $command;
+        }
+
+        try {
+            $found = test("which $command 2>/dev/null");
+        } catch (RunException) {
+            addRequirementRow("Package: $displayName", REQUIREMENT_SKIP, 'Check failed');
+
+            continue;
+        }
+
+        if ($found) {
+            addRequirementRow("Package: $displayName", REQUIREMENT_OK, 'Installed');
+        } else {
+            addRequirementRow("Package: $displayName", REQUIREMENT_FAIL, "Command '$command' not found");
+        }
+    }
+})->hidden();

--- a/deployer/requirements/task/check_php_extensions.php
+++ b/deployer/requirements/task/check_php_extensions.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use Deployer\Exception\RunException;
+
+task('requirements:check:php_extensions', function (): void {
+    if (!get('requirements_check_php_extensions_enabled')) {
+        return;
+    }
+
+    try {
+        $loadedModules = strtolower(run('php -m 2>/dev/null'));
+    } catch (RunException) {
+        addRequirementRow('PHP Extensions', REQUIREMENT_SKIP, 'Could not retrieve PHP modules');
+
+        return;
+    }
+
+    $moduleLines = array_map('trim', explode("\n", $loadedModules));
+
+    foreach (get('requirements_php_extensions') as $extension) {
+        $found = in_array(strtolower($extension), $moduleLines, true);
+
+        if ($found) {
+            addRequirementRow("PHP ext: $extension", REQUIREMENT_OK, 'Loaded');
+        } else {
+            addRequirementRow("PHP ext: $extension", REQUIREMENT_FAIL, 'Not loaded');
+        }
+    }
+})->hidden();

--- a/deployer/requirements/task/check_php_settings.php
+++ b/deployer/requirements/task/check_php_settings.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use Deployer\Exception\RunException;
+
+task('requirements:check:php_settings', function (): void {
+    if (!get('requirements_check_php_settings_enabled')) {
+        return;
+    }
+
+    // Retrieve PHP version
+    try {
+        $phpVersion = trim(run('php -r "echo PHP_VERSION;" 2>/dev/null'));
+        addRequirementRow('PHP version', REQUIREMENT_OK, $phpVersion);
+    } catch (RunException) {
+        addRequirementRow('PHP version', REQUIREMENT_SKIP, 'Could not determine PHP version');
+    }
+
+    foreach (get('requirements_php_settings') as $setting => $expected) {
+        try {
+            $actual = trim(run(sprintf(
+                "php -r \"echo ini_get('%s');\" 2>/dev/null",
+                $setting
+            )));
+        } catch (RunException) {
+            addRequirementRow("PHP: $setting", REQUIREMENT_SKIP, 'Could not read setting');
+
+            continue;
+        }
+
+        if ($actual === '') {
+            addRequirementRow("PHP: $setting", REQUIREMENT_WARN, "Not set (expected: $expected)");
+
+            continue;
+        }
+
+        $meets = meetsPhpRequirement($actual, (string) $expected, $setting);
+        $isComparison = in_array($setting, REQUIREMENT_BYTE_SETTINGS, true)
+            || in_array($setting, REQUIREMENT_NUMERIC_SETTINGS, true);
+        $info = $meets
+            ? $actual
+            : ($isComparison ? "$actual (expected: >= $expected)" : "$actual (expected: $expected)");
+        addRequirementRow(
+            "PHP: $setting",
+            $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL,
+            $info
+        );
+    }
+})->hidden();

--- a/deployer/requirements/task/check_user.php
+++ b/deployer/requirements/task/check_user.php
@@ -13,10 +13,11 @@ task('requirements:check:user', function (): void {
 
     $expectedGroup = get('requirements_user_group');
 
-    // Check primary group
+    // Check group membership (primary + supplementary)
     try {
+        $groups = explode(' ', trim(run('id -Gn')));
+        $meets = in_array($expectedGroup, $groups, true);
         $actualGroup = trim(run('id -gn'));
-        $meets = ($actualGroup === $expectedGroup);
         addRequirementRow(
             'User group',
             $meets ? REQUIREMENT_OK : REQUIREMENT_WARN,

--- a/deployer/requirements/task/check_user.php
+++ b/deployer/requirements/task/check_user.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use Deployer\Exception\RunException;
+
+task('requirements:check:user', function (): void {
+    if (!get('requirements_check_user_enabled')) {
+        return;
+    }
+
+    $expectedGroup = get('requirements_user_group');
+
+    // Check primary group
+    try {
+        $actualGroup = trim(run('id -gn'));
+        $meets = ($actualGroup === $expectedGroup);
+        addRequirementRow(
+            'User group',
+            $meets ? REQUIREMENT_OK : REQUIREMENT_WARN,
+            $meets ? $actualGroup : "$actualGroup (expected: $expectedGroup)"
+        );
+    } catch (RunException) {
+        addRequirementRow('User group', REQUIREMENT_SKIP, 'Could not determine user group');
+    }
+
+    // Check deploy path existence
+    if (!test('[ -d {{deploy_path}} ]')) {
+        addRequirementRow('Deploy path', REQUIREMENT_FAIL, '{{deploy_path}} does not exist');
+
+        return;
+    }
+
+    // Check deploy path owner
+    try {
+        $remoteUser = get('remote_user');
+        $pathOwner = trim(run('stat -c "%U" {{deploy_path}}'));
+        $meets = ($pathOwner === $remoteUser);
+        addRequirementRow(
+            'Deploy path owner',
+            $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL,
+            $meets ? "Owned by $pathOwner" : "Owned by $pathOwner (expected: $remoteUser)"
+        );
+    } catch (RunException) {
+        addRequirementRow('Deploy path owner', REQUIREMENT_SKIP, 'Could not check ownership');
+    }
+
+    // Check deploy path permissions
+    $expectedPerms = get('requirements_deploy_path_permissions');
+
+    try {
+        $actualPerms = trim(run('stat -c "%a" {{deploy_path}}'));
+        $meets = ($actualPerms === $expectedPerms);
+        addRequirementRow(
+            'Deploy path permissions',
+            $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL,
+            $meets ? $actualPerms : "$actualPerms (expected: $expectedPerms)"
+        );
+    } catch (RunException) {
+        addRequirementRow('Deploy path permissions', REQUIREMENT_SKIP, 'Could not check permissions');
+    }
+
+    // Check deploy path group
+    try {
+        $pathGroup = trim(run('stat -c "%G" {{deploy_path}}'));
+        $meets = ($pathGroup === $expectedGroup);
+        addRequirementRow(
+            'Deploy path group',
+            $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL,
+            $meets ? $pathGroup : "$pathGroup (expected: $expectedGroup)"
+        );
+    } catch (RunException) {
+        addRequirementRow('Deploy path group', REQUIREMENT_SKIP, 'Could not check group');
+    }
+})->hidden();

--- a/deployer/requirements/task/requirements.php
+++ b/deployer/requirements/task/requirements.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+task('requirements:check', [
+    'requirements:check:locales',
+    'requirements:check:packages',
+    'requirements:check:php_extensions',
+    'requirements:check:php_settings',
+    'requirements:check:database',
+    'requirements:check:user',
+    'requirements:check:env',
+    'requirements:check:summary',
+])->desc('Check server requirements');
+
+task('requirements:check:summary', function (): void {
+    renderRequirementsTable();
+})->hidden();

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,0 +1,99 @@
+# Requirements check
+
+The requirements check validates that target servers meet the necessary prerequisites for a TYPO3 or Symfony deployment. This is particularly useful when working with external hosters where servers are managed by third-party administrators.
+
+## General
+
+All checks run remotely via SSH on the deployment target. The results are displayed in a summary table with status indicators (OK, FAIL, WARN, SKIP).
+
+The default settings can be found within the [set.php](../deployer/requirements/config/set.php) file.
+
+```bash
+$ dep requirements:check [host]
+```
+
+## Checks
+
+### Locales
+
+Verifies that required system locales are available (default: `de_DE.utf8`, `en_US.utf8`).
+
+### System packages
+
+Checks for required CLI tools: rsync, curl, graphicsmagick, ghostscript, git, gzip, mariadb-client, unzip, patch, exiftool, composer.
+
+### PHP extensions
+
+Verifies that required PHP extensions are loaded. The list adapts automatically based on the configured `app_type` (typo3/symfony).
+
+### PHP settings
+
+Checks PHP CLI configuration values against expected minimums:
+
+| Setting | Expected |
+|---------|----------|
+| max_execution_time | >= 240 |
+| memory_limit | >= 512M |
+| max_input_vars | >= 1500 |
+| date.timezone | Europe/Berlin |
+| post_max_size | >= 31M |
+| upload_max_filesize | >= 30M |
+| opcache.memory_consumption | >= 256 |
+
+### Database client
+
+Checks for the availability of the `mariadb` or `mysql` client and validates the version against the configured minimum (default: >= 10.2.7).
+
+### User and permissions
+
+Validates that the SSH user belongs to the expected web server group (default: `www-data`) and that the deploy path has the correct owner, group, and permissions (default: `2770`).
+
+### Environment file
+
+Checks that the `.env` file exists in the shared directory and that all required environment variables are present. The required variables adapt automatically based on `app_type`.
+
+## Configuration
+
+All settings use the `requirements_` prefix and can be overridden in the consuming project:
+
+```php
+// Disable specific checks
+set('requirements_check_database_enabled', false);
+
+// Override PHP extensions list
+set('requirements_php_extensions', ['curl', 'gd', 'mbstring', 'xml', 'intl']);
+
+// Override PHP settings thresholds
+set('requirements_php_settings', [
+    'memory_limit' => '1G',
+    'max_execution_time' => '300',
+]);
+
+// Override required system packages
+set('requirements_packages', [
+    'rsync' => 'rsync',
+    'git' => 'git',
+    'composer' => 'composer',
+]);
+
+// Override locales
+set('requirements_locales', ['de_DE.utf8', 'en_US.utf8', 'fr_FR.utf8']);
+
+// Override user group
+set('requirements_user_group', 'apache');
+
+// Override required env variables
+set('requirements_env_vars', ['DATABASE_URL', 'APP_SECRET']);
+```
+
+## Extending with custom checks
+
+Custom checks can be added via Deployer's `before()` hook:
+
+```php
+task('requirements:check:my_vhost', function () {
+    addRequirementRow('Apache VHost', \Deployer\REQUIREMENT_OK, 'Configured');
+})->hidden();
+
+before('requirements:check:summary', 'requirements:check:my_vhost');
+```

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -42,7 +42,7 @@ Checks PHP CLI configuration values against expected minimums:
 
 ### Database client
 
-Checks for the availability of the `mariadb` or `mysql` client and validates the version against the configured minimum (default: >= 10.2.7).
+Checks for the availability of the `mariadb` or `mysql` client and validates the version against client-specific minimums (MariaDB: >= 10.2.7, MySQL: >= 8.0.0).
 
 ### User and permissions
 


### PR DESCRIPTION
## Summary

- Add `requirements:check` Deployer task to validate target server prerequisites via SSH
- Checks locales, system packages, PHP extensions, PHP settings, database client, user/permissions, and .env variables
- Framework-aware configuration (auto-adapts for TYPO3 via `app_type`)
- All checks configurable and individually toggleable per project

## Changes

- `deployer/requirements/functions.php` - Core helpers: result accumulator, status formatting, byte parser, env reader
- `deployer/requirements/config/set.php` - Configurable defaults with `requirements_*` prefix
- `deployer/requirements/task/requirements.php` - Composite task and summary table renderer
- `deployer/requirements/task/check_locales.php` - Locale availability check
- `deployer/requirements/task/check_packages.php` - System package/CLI tool check
- `deployer/requirements/task/check_php_extensions.php` - PHP extension check
- `deployer/requirements/task/check_php_settings.php` - PHP ini settings check with version output
- `deployer/requirements/task/check_database.php` - MariaDB/MySQL client version check
- `deployer/requirements/task/check_user.php` - User group, deploy path owner/permissions check
- `deployer/requirements/task/check_env.php` - Shared .env file and required variables check
- `autoload.php` - Register new module
- `docs/REQUIREMENTS.md` - Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive pre-deployment requirements check that validates locales, system packages, PHP extensions, PHP settings, database client/version, user/permissions, and environment variables; includes a summarized results table.

* **Documentation**
  * Added a detailed guide explaining configuration options, how to run the checks, and examples for customizing or extending requirement checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->