### PR TITLE
feat: add deploy:writable:chmod task for proper file permissions

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -2,6 +2,7 @@
 	"symbol-whitelist": [
 		"Normalizer",
 		"after",
+		"applyDeployPermissions",
 		"askConfirmation",
 		"before",
 		"checkVerbosity",
@@ -14,6 +15,7 @@
 		"Deployer\\has",
 		"Deployer\\input",
 		"Deployer\\run",
+		"Deployer\\applyDeployPermissions",
 		"Deployer\\runExtended",
 		"Deployer\\set",
 		"Deployer\\test",

--- a/deployer/symfony/config/set.php
+++ b/deployer/symfony/config/set.php
@@ -30,8 +30,11 @@ set('writable_dirs', [
 ]);
 
 set('writable_mode', 'chmod');
-set('writable_chmod_mode', '0770'); // todo maybe change to '2770'
-set('writable_chmod_recursive', false);
+set('writable_chmod_mode', '2770');
+set('writable_recursive', false);
+set('writable_chmod_mode_files', '644');
+set('writable_chmod_mode_dirs', '2755');
+set('writable_chmod_mode_writable_dirs', '2775');
 
 set('bin/console', function () {
     $activePath = get('deploy_path') . '/' . (test('[ -L {{deploy_path}}/release ]') ? 'release' : 'current');

--- a/deployer/symfony/task/deploy_writable_chmod.php
+++ b/deployer/symfony/task/deploy_writable_chmod.php
@@ -3,12 +3,8 @@
 namespace Deployer;
 
 /**
- * This task will adjust the dir/file rights
- * ToDo: check deploy:writable to solve this?
+ * Adjusts file and directory permissions for Symfony deployments.
  */
-task('deploy:writable:chmod', function() {
-    runExtended("cd {{ release_path }} && chmod 775 var var/cache ../../shared/var/log");
-    runExtended("cd {{ release_path }} && find . -path \"./var\" -prune -o -type d -exec chmod 755 {} +");
-    runExtended("cd {{ release_path }} && find . -type f -exec chmod 644 {} +");
-    runExtended("cd {{ release_path }} && chmod -R 775 var/cache");
-})->desc('Adjust file rights for release directory');
+task('deploy:writable:chmod', function () {
+    applyDeployPermissions();
+})->desc('Adjust file and directory permissions for Symfony release');

--- a/deployer/typo3/autoload.php
+++ b/deployer/typo3/autoload.php
@@ -14,6 +14,7 @@ require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/autoload.php');
 
 require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/deployer/typo3/functions.php');
 require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/deployer/typo3/config/set.php');
+require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/deployer/typo3/task/deploy_writable_chmod.php');
 require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/deployer/typo3/task/deploy.php');
 require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/deployer/typo3/task/deploy_cache.php');
 require_once($vendorRoot . '/vendor/move-elevator/deployer-tools/deployer/typo3/task/deploy_database.php');

--- a/deployer/typo3/config/set.php
+++ b/deployer/typo3/config/set.php
@@ -31,6 +31,9 @@ set('shared_files', [
 set('writable_mode', 'chmod');
 set('writable_chmod_mode', '2770');
 set('writable_recursive', false);
+set('writable_chmod_mode_files', '644');
+set('writable_chmod_mode_dirs', '2755');
+set('writable_chmod_mode_writable_dirs', '2775');
 set('writable_dirs',  [
     '{{web_path}}typo3conf',
     '{{web_path}}typo3temp',

--- a/deployer/typo3/task/deploy.php
+++ b/deployer/typo3/task/deploy.php
@@ -27,6 +27,9 @@ task('deploy', [
     // Standard deployer task.
     'deploy:writable',
 
+    // Adjust file and directory permissions (SGID, CLI binary, shared dirs).
+    'deploy:writable:chmod',
+
     // Standard deployer task.
     'deploy:clear_paths',
 

--- a/deployer/typo3/task/deploy_writable_chmod.php
+++ b/deployer/typo3/task/deploy_writable_chmod.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Deployer;
+
+/**
+ * Adjusts file and directory permissions for TYPO3 deployments.
+ *
+ * Extends the shared permission logic with TYPO3-specific handling
+ * for the CLI binary (vendor/bin/typo3 and vendor/bin/typo3cms).
+ */
+task('deploy:writable:chmod', function () {
+    applyDeployPermissions();
+
+    // Make TYPO3 CLI binary executable (supports both legacy and current binary names)
+    foreach (['vendor/bin/typo3', 'vendor/bin/typo3cms'] as $binary) {
+        if (test("[ -f {{ release_path }}/$binary ]")) {
+            runExtended("chmod 0755 {{ release_path }}/$binary");
+        }
+    }
+})->desc('Adjust file and directory permissions for TYPO3 release');


### PR DESCRIPTION
## Summary

- Add shared `applyDeployPermissions()` function for standardized file/directory permissions
- Add `deploy:writable:chmod` task for TYPO3 (new) and refactor existing Symfony task
- Fix Symfony config: `writable_chmod_mode` from `0770` to `2770`, correct `writable_recursive` key name

## Problem

The standard `deploy:writable` task only applies a flat `chmod` on `writable_dirs` without differentiating between files and directories. This causes permission issues in TYPO3 (and Symfony) projects:

- No SGID bit for group inheritance on directories
- No separation of file (`644`) vs directory (`2755`) permissions
- `var/cache` not created before cache warmup
- TYPO3 CLI binary not made executable
- Shared directory permissions never corrected after initial setup

## Changes

- `deployer/functions.php` - New `applyDeployPermissions()` with configurable modes and fallback defaults
- `deployer/typo3/task/deploy_writable_chmod.php` - New TYPO3 task (calls shared function + CLI binary chmod)
- `deployer/typo3/task/deploy.php` - Add task to deploy sequence after `deploy:writable`
- `deployer/typo3/autoload.php` - Register new task file
- `deployer/typo3/config/set.php` - Add `writable_chmod_mode_files`, `writable_chmod_mode_dirs`, `writable_chmod_mode_writable_dirs`
- `deployer/symfony/task/deploy_writable_chmod.php` - Refactored to use shared function
- `deployer/symfony/config/set.php` - Fix chmod mode to `2770`, fix dead `writable_chmod_recursive` key, add new config vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced granular file and directory permission controls during deployments, allowing separate and configurable permission settings for different file types and writable directories.
  * Enhanced TYPO3 deployments with automatic permission adjustment for CLI utilities and executable binaries.

* **Chores**
  * Refactored permission handling to centralize file and directory permission management across deployment frameworks for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->