### PR TITLE
fix: remove reference to removed deployer-instance package

### DIFF
--- a/deployer/symfony/Loader.php
+++ b/deployer/symfony/Loader.php
@@ -12,7 +12,6 @@ class Loader
         require_once 'recipe/common.php';
 
         new Load([
-                ['path' => 'vendor/sourcebroker/deployer-instance/deployer'],
                 ['path' => 'vendor/sourcebroker/deployer-extended/deployer'],
             ]
         );

--- a/deployer/typo3/Loader.php
+++ b/deployer/typo3/Loader.php
@@ -12,7 +12,6 @@ class Loader
         require_once 'recipe/common.php';
 
         new Load([
-                ['path' => 'vendor/sourcebroker/deployer-instance/deployer'],
                 ['path' => 'vendor/sourcebroker/deployer-extended/deployer'],
             ]
         );


### PR DESCRIPTION
## Summary

- Remove obsolete `sourcebroker/deployer-instance` path from TYPO3 and Symfony Loaders
- Package was removed as dependency in `deployer-extended` v20.0.0, causing `require_once` failures

## Changes

- `deployer/typo3/Loader.php` - Remove deployer-instance path from Load config
- `deployer/symfony/Loader.php` - Remove deployer-instance path from Load config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed redundant vendor path references from deployer loader configurations in Symfony and TYPO3, streamlining the deployment initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->