### PR TITLE
fix: requirements check package detection and MariaDB version parsing

### DIFF
--- a/deployer/requirements/task/check_database.php
+++ b/deployer/requirements/task/check_database.php
@@ -35,7 +35,9 @@ task('requirements:check:database', function (): void {
         return;
     }
 
-    if (preg_match('/Distrib\s+([\d.]+)/', $versionOutput, $matches)) {
+    if (preg_match('/Distrib\s+([\d.]+)/', $versionOutput, $matches)
+        || preg_match('/([\d.]+)-MariaDB/', $versionOutput, $matches)
+    ) {
         $actualVersion = $matches[1];
         $minVersion = get('requirements_mariadb_min_version');
         $meets = version_compare($actualVersion, $minVersion, '>=');

--- a/deployer/requirements/task/check_packages.php
+++ b/deployer/requirements/task/check_packages.php
@@ -17,7 +17,7 @@ task('requirements:check:packages', function (): void {
         }
 
         try {
-            $found = test("which $command 2>/dev/null");
+            $found = test("command -v $command >/dev/null 2>&1");
         } catch (RunException) {
             addRequirementRow("Package: $displayName", REQUIREMENT_SKIP, 'Check failed');
 


### PR DESCRIPTION
## Summary

- Fix package detection using `command -v` with suppressed stdout instead of `which`
- Add support for MariaDB 11.x version output format

## Changes

- `deployer/requirements/task/check_packages.php` - Replace `which` with `command -v >/dev/null 2>&1` to work with Deployer's `test()` function, which compares full stdout output
- `deployer/requirements/task/check_database.php` - Add regex pattern for MariaDB 11.x format (`11.8.3-MariaDB` instead of `Distrib 10.x.y`)