### PR TITLE
feat: align requirements:check with TYPO3 v13 docs and add EOL checks

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -43,11 +43,14 @@ require_once(__DIR__ . '/deployer/requirements/config/set.php');
 require_once(__DIR__ . '/deployer/requirements/task/requirements.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_locales.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_packages.php');
+require_once(__DIR__ . '/deployer/requirements/task/check_image_processing.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_php_extensions.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_php_settings.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_database.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_user.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_env.php');
+require_once(__DIR__ . '/deployer/requirements/task/check_eol.php');
+require_once(__DIR__ . '/deployer/requirements/task/list.php');
 
 /*
  * dev

--- a/deployer/requirements/config/set.php
+++ b/deployer/requirements/config/set.php
@@ -10,11 +10,13 @@ set('requirements_rows', []);
 // Enable/disable per check category
 set('requirements_check_locales_enabled', true);
 set('requirements_check_packages_enabled', true);
+set('requirements_check_image_processing_enabled', true);
 set('requirements_check_php_extensions_enabled', true);
 set('requirements_check_php_settings_enabled', true);
 set('requirements_check_database_enabled', true);
 set('requirements_check_user_enabled', true);
 set('requirements_check_env_enabled', true);
+set('requirements_check_eol_enabled', true);
 
 // Locales
 set('requirements_locales', ['de_DE.utf8', 'en_US.utf8']);
@@ -23,7 +25,6 @@ set('requirements_locales', ['de_DE.utf8', 'en_US.utf8']);
 set('requirements_packages', [
     'rsync' => 'rsync',
     'curl' => 'curl',
-    'graphicsmagick' => 'gm',
     'ghostscript' => 'gs',
     'git' => 'git',
     'gzip' => 'gzip',
@@ -34,35 +35,48 @@ set('requirements_packages', [
     'composer' => 'composer',
 ]);
 
+// PHP minimum version (framework-aware)
+set('requirements_php_min_version', function (): string {
+    if (has('app_type') && get('app_type') === 'typo3') {
+        return '8.2.0';
+    }
+
+    return '8.1.0';
+});
+
 // PHP extensions (framework-aware)
 set('requirements_php_extensions', function (): array {
     if (has('app_type') && get('app_type') === 'typo3') {
         return [
-            'curl',
-            'gd',
-            'mbstring',
-            'soap',
-            'xml',
-            'zip',
-            'intl',
-            'apcu',
             'pdo',
+            'session',
+            'xml',
+            'filter',
+            'tokenizer',
+            'mbstring',
+            'intl',
             'pdo_mysql',
-            'json',
             'fileinfo',
+            'gd',
+            'zip',
             'openssl',
+            'curl',
+            'apcu',
         ];
     }
 
     return [
+        'pdo',
+        'session',
+        'xml',
+        'filter',
+        'tokenizer',
+        'mbstring',
+        'intl',
+        'pdo_mysql',
         'curl',
         'gd',
-        'mbstring',
-        'xml',
         'zip',
-        'intl',
-        'pdo',
-        'pdo_mysql',
     ];
 });
 
@@ -71,6 +85,7 @@ set('requirements_php_settings', [
     'max_execution_time' => '240',
     'memory_limit' => '512M',
     'max_input_vars' => '1500',
+    'pcre.jit' => '1',
     'date.timezone' => 'Europe/Berlin',
     'post_max_size' => '31M',
     'upload_max_filesize' => '30M',
@@ -78,8 +93,19 @@ set('requirements_php_settings', [
 ]);
 
 // Database
-set('requirements_mariadb_min_version', '10.2.7');
-set('requirements_mysql_min_version', '8.0.0');
+set('requirements_mariadb_min_version', '10.4.3');
+set('requirements_mysql_min_version', '8.0.17');
+
+// Image processing
+set('requirements_graphicsmagick_min_version', '1.3');
+set('requirements_imagemagick_min_version', '6.0');
+
+// Composer
+set('requirements_composer_min_version', '2.1.0');
+
+// End-of-life check (endoflife.date API)
+set('requirements_eol_warn_months', 6);
+set('requirements_eol_api_timeout', 5);
 
 // User / permissions
 set('requirements_user_group', 'www-data');

--- a/deployer/requirements/functions.php
+++ b/deployer/requirements/functions.php
@@ -155,7 +155,7 @@ function detectPackageVersion(string $command): ?string
     try {
         $output = trim(run($versionCmd));
 
-        if ($output !== '' && preg_match('/(\d+[\d.]+)/', $output, $matches)) {
+        if ($output !== '' && preg_match('/(\d+[\d.]*)/', $output, $matches)) {
             return $matches[1];
         }
     } catch (RunException) {

--- a/deployer/requirements/functions.php
+++ b/deployer/requirements/functions.php
@@ -180,13 +180,16 @@ function detectDatabaseProduct(): ?array
                 continue;
             }
 
-            if (preg_match('/Distrib\s+((\d+\.\d+)[\d.]*)/', $versionOutput, $matches)
+            if (str_contains($versionOutput, 'MariaDB') && (
+                preg_match('/Distrib\s+((\d+\.\d+)[\d.]*)/', $versionOutput, $matches)
                 || preg_match('/((\d+\.\d+)[\d.]*)-MariaDB/', $versionOutput, $matches)
-            ) {
+            )) {
                 return ['product' => 'mariadb', 'label' => 'MariaDB', 'version' => $matches[1], 'cycle' => $matches[2]];
             }
 
-            if (preg_match('/Ver\s+((\d+\.\d+)[\d.]*)/', $versionOutput, $matches)) {
+            if (preg_match('/Distrib\s+((\d+\.\d+)[\d.]*)/', $versionOutput, $matches)
+                || preg_match('/Ver\s+((\d+\.\d+)[\d.]*)/', $versionOutput, $matches)
+            ) {
                 return ['product' => 'mysql', 'label' => 'MySQL', 'version' => $matches[1], 'cycle' => $matches[2]];
             }
         } catch (RunException) {
@@ -274,6 +277,13 @@ function evaluateEolStatus(string $label, array $cycle, int $warnMonths): void
 
         if ($now >= $warnDate) {
             $interval = $now->diff($eolDate);
+
+            if ($interval->invert) {
+                addRequirementRow("EOL: $label", REQUIREMENT_FAIL, "End of Life since $eolFrom");
+
+                return;
+            }
+
             $months = $interval->y * 12 + $interval->m;
             $remaining = $months > 0 ? "in $months month(s)" : 'imminent';
             addRequirementRow("EOL: $label", REQUIREMENT_WARN, "EOL $remaining ($eolFrom)");

--- a/deployer/requirements/task/check_database.php
+++ b/deployer/requirements/task/check_database.php
@@ -4,60 +4,27 @@ declare(strict_types=1);
 
 namespace Deployer;
 
-use Deployer\Exception\RunException;
-
 task('requirements:check:database', function (): void {
     if (!get('requirements_check_database_enabled')) {
         return;
     }
 
-    // Try mariadb command first (newer MariaDB installations), then fall back to mysql
-    $versionOutput = '';
-    $clientFound = false;
+    $db = detectDatabaseProduct();
 
-    foreach (['mariadb', 'mysql'] as $command) {
-        try {
-            $versionOutput = trim(run("$command --version 2>/dev/null"));
-
-            if ($versionOutput !== '') {
-                $clientFound = true;
-
-                break;
-            }
-        } catch (RunException) {
-            continue;
-        }
-    }
-
-    if (!$clientFound) {
+    if ($db === null) {
         addRequirementRow('Database client', REQUIREMENT_SKIP, 'Neither mariadb nor mysql command available');
 
         return;
     }
 
-    if (preg_match('/Distrib\s+([\d.]+)/', $versionOutput, $matches)
-        || preg_match('/([\d.]+)-MariaDB/', $versionOutput, $matches)
-    ) {
-        $actualVersion = $matches[1];
-        $minVersion = get('requirements_mariadb_min_version');
-        $meets = version_compare($actualVersion, $minVersion, '>=');
-        $info = $meets ? "MariaDB $actualVersion" : "MariaDB $actualVersion (required: >= $minVersion)";
-        addRequirementRow(
-            'Database client',
-            $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL,
-            $info
-        );
-    } elseif (preg_match('/Ver\s+([\d.]+)/', $versionOutput, $matches)) {
-        $actualVersion = $matches[1];
-        $minVersion = get('requirements_mysql_min_version');
-        $meets = version_compare($actualVersion, $minVersion, '>=');
-        $info = $meets ? "MySQL $actualVersion" : "MySQL $actualVersion (required: >= $minVersion)";
-        addRequirementRow(
-            'Database client',
-            $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL,
-            $info
-        );
-    } else {
-        addRequirementRow('Database client', REQUIREMENT_WARN, "Could not parse version: $versionOutput");
-    }
+    $minVersion = $db['product'] === 'mariadb'
+        ? get('requirements_mariadb_min_version')
+        : get('requirements_mysql_min_version');
+
+    $meets = version_compare($db['version'], $minVersion, '>=');
+    $info = $meets
+        ? "{$db['label']} {$db['version']}"
+        : "{$db['label']} {$db['version']} (required: >= $minVersion)";
+
+    addRequirementRow('Database client', $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL, $info);
 })->hidden();

--- a/deployer/requirements/task/check_eol.php
+++ b/deployer/requirements/task/check_eol.php
@@ -15,7 +15,7 @@ task('requirements:check:eol', function (): void {
     }
 
     $warnMonths = max(1, (int) get('requirements_eol_warn_months'));
-    $timeout = (int) get('requirements_eol_api_timeout');
+    $timeout = max(1, (int) get('requirements_eol_api_timeout'));
 
     // Check PHP EOL
     try {

--- a/deployer/requirements/task/check_eol.php
+++ b/deployer/requirements/task/check_eol.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use Deployer\Exception\RunException;
+
+// Version detection runs on the remote server (via run()),
+// but EOL API lookups run locally (via file_get_contents)
+// to avoid outbound HTTP from production servers.
+task('requirements:check:eol', function (): void {
+    if (!get('requirements_check_eol_enabled')) {
+        return;
+    }
+
+    $warnMonths = max(1, (int) get('requirements_eol_warn_months'));
+    $timeout = (int) get('requirements_eol_api_timeout');
+
+    // Check PHP EOL
+    try {
+        $phpCycle = trim(run('php -r "echo PHP_MAJOR_VERSION.\'.\'.PHP_MINOR_VERSION;" 2>/dev/null'));
+    } catch (RunException) {
+        $phpCycle = '';
+    }
+
+    if ($phpCycle !== '') {
+        checkEolForProduct('PHP', 'php', $phpCycle, $warnMonths, $timeout);
+    }
+
+    // Check database EOL
+    $db = detectDatabaseProduct();
+
+    if ($db !== null) {
+        checkEolForProduct($db['label'], $db['product'], $db['cycle'], $warnMonths, $timeout);
+    }
+})->hidden();

--- a/deployer/requirements/task/check_image_processing.php
+++ b/deployer/requirements/task/check_image_processing.php
@@ -21,12 +21,12 @@ task('requirements:check:image_processing', function (): void {
         if ($gmOutput !== '' && preg_match('/GraphicsMagick\s+([\d.]+)/', $gmOutput, $matches)) {
             $actualVersion = $matches[1];
             $meets = version_compare($actualVersion, $gmMinVersion, '>=');
-            $info = $meets
-                ? "GraphicsMagick $actualVersion"
-                : "GraphicsMagick $actualVersion (required: >= $gmMinVersion)";
-            addRequirementRow('Image processing', $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL, $info);
 
-            return;
+            if ($meets) {
+                addRequirementRow('Image processing', REQUIREMENT_OK, "GraphicsMagick $actualVersion");
+
+                return;
+            }
         }
     } catch (RunException) {
         // GraphicsMagick not available, try ImageMagick

--- a/deployer/requirements/task/check_image_processing.php
+++ b/deployer/requirements/task/check_image_processing.php
@@ -13,6 +13,7 @@ task('requirements:check:image_processing', function (): void {
 
     $gmMinVersion = get('requirements_graphicsmagick_min_version');
     $imMinVersion = get('requirements_imagemagick_min_version');
+    $gmVersionFail = false;
 
     // Try GraphicsMagick first (recommended)
     try {
@@ -27,6 +28,8 @@ task('requirements:check:image_processing', function (): void {
 
                 return;
             }
+
+            $gmVersionFail = "GraphicsMagick $actualVersion (required: >= $gmMinVersion)";
         }
     } catch (RunException) {
         // GraphicsMagick not available, try ImageMagick
@@ -55,6 +58,8 @@ task('requirements:check:image_processing', function (): void {
     addRequirementRow(
         'Image processing',
         REQUIREMENT_FAIL,
-        "Neither GraphicsMagick (>= $gmMinVersion) nor ImageMagick (>= $imMinVersion) found"
+        $gmVersionFail !== false
+            ? "$gmVersionFail — ImageMagick (>= $imMinVersion) not found"
+            : "Neither GraphicsMagick (>= $gmMinVersion) nor ImageMagick (>= $imMinVersion) found"
     );
 })->hidden();

--- a/deployer/requirements/task/check_image_processing.php
+++ b/deployer/requirements/task/check_image_processing.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use Deployer\Exception\RunException;
+
+task('requirements:check:image_processing', function (): void {
+    if (!get('requirements_check_image_processing_enabled')) {
+        return;
+    }
+
+    $gmMinVersion = get('requirements_graphicsmagick_min_version');
+    $imMinVersion = get('requirements_imagemagick_min_version');
+
+    // Try GraphicsMagick first (recommended)
+    try {
+        $gmOutput = trim(run('gm version 2>/dev/null | head -1'));
+
+        if ($gmOutput !== '' && preg_match('/GraphicsMagick\s+([\d.]+)/', $gmOutput, $matches)) {
+            $actualVersion = $matches[1];
+            $meets = version_compare($actualVersion, $gmMinVersion, '>=');
+            $info = $meets
+                ? "GraphicsMagick $actualVersion"
+                : "GraphicsMagick $actualVersion (required: >= $gmMinVersion)";
+            addRequirementRow('Image processing', $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL, $info);
+
+            return;
+        }
+    } catch (RunException) {
+        // GraphicsMagick not available, try ImageMagick
+    }
+
+    // Fallback to ImageMagick (magick for IM7+, convert for legacy)
+    foreach (['magick', 'convert'] as $imCommand) {
+        try {
+            $imOutput = trim(run("$imCommand -version 2>/dev/null | head -1"));
+
+            if ($imOutput !== '' && preg_match('/ImageMagick\s+([\d.]+)/', $imOutput, $matches)) {
+                $actualVersion = $matches[1];
+                $meets = version_compare($actualVersion, $imMinVersion, '>=');
+                $info = $meets
+                    ? "ImageMagick $actualVersion"
+                    : "ImageMagick $actualVersion (required: >= $imMinVersion)";
+                addRequirementRow('Image processing', $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL, $info);
+
+                return;
+            }
+        } catch (RunException) {
+            continue;
+        }
+    }
+
+    addRequirementRow(
+        'Image processing',
+        REQUIREMENT_FAIL,
+        "Neither GraphicsMagick (>= $gmMinVersion) nor ImageMagick (>= $imMinVersion) found"
+    );
+})->hidden();

--- a/deployer/requirements/task/check_packages.php
+++ b/deployer/requirements/task/check_packages.php
@@ -24,10 +24,40 @@ task('requirements:check:packages', function (): void {
             continue;
         }
 
-        if ($found) {
-            addRequirementRow("Package: $displayName", REQUIREMENT_OK, 'Installed');
-        } else {
+        if (!$found) {
             addRequirementRow("Package: $displayName", REQUIREMENT_FAIL, "Command '$command' not found");
+
+            continue;
+        }
+
+        // Composer has version validation against a minimum
+        if ($command === 'composer') {
+            try {
+                $versionOutput = trim(run('composer --version 2>/dev/null'));
+                $minVersion = get('requirements_composer_min_version');
+
+                if (preg_match('/Composer\s+(?:version\s+)?([\d.]+)/', $versionOutput, $matches)) {
+                    $actualVersion = $matches[1];
+                    $meets = version_compare($actualVersion, $minVersion, '>=');
+                    $info = $meets
+                        ? "Composer $actualVersion"
+                        : "Composer $actualVersion (required: >= $minVersion)";
+                    addRequirementRow("Package: $displayName", $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL, $info);
+
+                    continue;
+                }
+            } catch (RunException) {
+                // Fall through to generic version detection
+            }
+        }
+
+        // Try to retrieve version for informational display
+        $version = detectPackageVersion($command);
+
+        if ($version !== null) {
+            addRequirementRow("Package: $displayName", REQUIREMENT_OK, "$displayName $version");
+        } else {
+            addRequirementRow("Package: $displayName", REQUIREMENT_OK, 'Installed');
         }
     }
 })->hidden();

--- a/deployer/requirements/task/check_php_settings.php
+++ b/deployer/requirements/task/check_php_settings.php
@@ -11,10 +11,13 @@ task('requirements:check:php_settings', function (): void {
         return;
     }
 
-    // Retrieve PHP version
+    // Retrieve and validate PHP version
     try {
         $phpVersion = trim(run('php -r "echo PHP_VERSION;" 2>/dev/null'));
-        addRequirementRow('PHP version', REQUIREMENT_OK, $phpVersion);
+        $minVersion = get('requirements_php_min_version');
+        $meets = version_compare($phpVersion, $minVersion, '>=');
+        $info = $meets ? $phpVersion : "$phpVersion (required: >= $minVersion)";
+        addRequirementRow('PHP version', $meets ? REQUIREMENT_OK : REQUIREMENT_FAIL, $info);
     } catch (RunException) {
         addRequirementRow('PHP version', REQUIREMENT_SKIP, 'Could not determine PHP version');
     }

--- a/deployer/requirements/task/list.php
+++ b/deployer/requirements/task/list.php
@@ -17,15 +17,20 @@ task('requirements:list', function (): void {
         writeln('');
         writeln('<fg=yellow;options=bold>PHP</>');
         writeln(sprintf('  Version:      >= %s', get('requirements_php_min_version')));
-        writeln(sprintf('  Extensions:   %s', implode(', ', get('requirements_php_extensions'))));
 
-        writeln('  Settings:');
+        if (get('requirements_check_php_extensions_enabled')) {
+            writeln(sprintf('  Extensions:   %s', implode(', ', get('requirements_php_extensions'))));
+        }
 
-        foreach (get('requirements_php_settings') as $setting => $value) {
-            $isComparison = in_array($setting, REQUIREMENT_BYTE_SETTINGS, true)
-                || in_array($setting, REQUIREMENT_NUMERIC_SETTINGS, true);
-            $operator = $isComparison ? '>=' : '=';
-            writeln(sprintf('    %-30s %s %s', $setting, $operator, $value));
+        if (get('requirements_check_php_settings_enabled')) {
+            writeln('  Settings:');
+
+            foreach (get('requirements_php_settings') as $setting => $value) {
+                $isComparison = in_array($setting, REQUIREMENT_BYTE_SETTINGS, true)
+                    || in_array($setting, REQUIREMENT_NUMERIC_SETTINGS, true);
+                $operator = $isComparison ? '>=' : '=';
+                writeln(sprintf('    %-30s %s %s', $setting, $operator, $value));
+            }
         }
     }
 

--- a/deployer/requirements/task/list.php
+++ b/deployer/requirements/task/list.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+task('requirements:list', function (): void {
+    $appType = has('app_type') ? get('app_type') : 'default';
+    $label = strtoupper($appType);
+
+    writeln('');
+    writeln("<fg=cyan;options=bold>Server Requirements ($label)</>");
+    writeln(str_repeat('=', 50));
+
+    // PHP
+    if (get('requirements_check_php_settings_enabled') || get('requirements_check_php_extensions_enabled')) {
+        writeln('');
+        writeln('<fg=yellow;options=bold>PHP</>');
+        writeln(sprintf('  Version:      >= %s', get('requirements_php_min_version')));
+        writeln(sprintf('  Extensions:   %s', implode(', ', get('requirements_php_extensions'))));
+
+        writeln('  Settings:');
+
+        foreach (get('requirements_php_settings') as $setting => $value) {
+            $isComparison = in_array($setting, REQUIREMENT_BYTE_SETTINGS, true)
+                || in_array($setting, REQUIREMENT_NUMERIC_SETTINGS, true);
+            $operator = $isComparison ? '>=' : '=';
+            writeln(sprintf('    %-30s %s %s', $setting, $operator, $value));
+        }
+    }
+
+    // Database
+    if (get('requirements_check_database_enabled')) {
+        writeln('');
+        writeln('<fg=yellow;options=bold>Database</>');
+        writeln(sprintf('  MariaDB:      >= %s', get('requirements_mariadb_min_version')));
+        writeln(sprintf('  MySQL:        >= %s', get('requirements_mysql_min_version')));
+    }
+
+    // Image Processing
+    if (get('requirements_check_image_processing_enabled')) {
+        writeln('');
+        writeln('<fg=yellow;options=bold>Image Processing</>');
+        writeln(sprintf(
+            '  GraphicsMagick >= %s (recommended) or ImageMagick >= %s',
+            get('requirements_graphicsmagick_min_version'),
+            get('requirements_imagemagick_min_version')
+        ));
+    }
+
+    // System Packages
+    if (get('requirements_check_packages_enabled')) {
+        writeln('');
+        writeln('<fg=yellow;options=bold>System Packages</>');
+
+        $packages = get('requirements_packages');
+        $packageNames = [];
+
+        foreach ($packages as $displayName => $command) {
+            $name = is_int($displayName) ? $command : $displayName;
+
+            if ($command === 'composer') {
+                $name .= sprintf(' (>= %s)', get('requirements_composer_min_version'));
+            }
+
+            $packageNames[] = $name;
+        }
+
+        writeln('  ' . implode(', ', $packageNames));
+    }
+
+    // Locales
+    if (get('requirements_check_locales_enabled')) {
+        writeln('');
+        writeln('<fg=yellow;options=bold>Locales</>');
+        writeln('  ' . implode(', ', get('requirements_locales')));
+    }
+
+    // User & Permissions
+    if (get('requirements_check_user_enabled')) {
+        writeln('');
+        writeln('<fg=yellow;options=bold>User & Permissions</>');
+        writeln(sprintf('  Group:        %s', get('requirements_user_group')));
+        writeln(sprintf('  Permissions:  %s (deploy path)', get('requirements_deploy_path_permissions')));
+    }
+
+    // End-of-life checks
+    if (get('requirements_check_eol_enabled')) {
+        writeln('');
+        writeln('<fg=yellow;options=bold>End-of-Life Checks</>');
+        writeln('  PHP and database versions checked against endoflife.date API');
+        writeln(sprintf('  Warning threshold: %d months before EOL', (int) get('requirements_eol_warn_months')));
+    }
+
+    // Environment Variables
+    if (get('requirements_check_env_enabled')) {
+        $envVars = get('requirements_env_vars');
+
+        if (!empty($envVars)) {
+            writeln('');
+            writeln('<fg=yellow;options=bold>Environment Variables</>');
+            writeln(sprintf('  File: {{deploy_path}}/shared/%s', get('requirements_env_file')));
+
+            foreach ($envVars as $var) {
+                writeln("  - $var");
+            }
+        }
+    }
+
+    writeln('');
+})->desc('List server requirements');

--- a/deployer/requirements/task/requirements.php
+++ b/deployer/requirements/task/requirements.php
@@ -7,11 +7,13 @@ namespace Deployer;
 task('requirements:check', [
     'requirements:check:locales',
     'requirements:check:packages',
+    'requirements:check:image_processing',
     'requirements:check:php_extensions',
     'requirements:check:php_settings',
     'requirements:check:database',
     'requirements:check:user',
     'requirements:check:env',
+    'requirements:check:eol',
     'requirements:check:summary',
 ])->desc('Check server requirements');
 


### PR DESCRIPTION
## Summary

- Align `requirements:check` with official TYPO3 v13 system requirements documentation
- Add End-of-Life checks against the endoflife.date API
- Add `requirements:list` command for human-readable requirement output
- Display installed versions for all system packages

## Changes

### Core alignment with TYPO3 v13 docs
- `config/set.php` — Update DB minimums (MariaDB 10.4.3, MySQL 8.0.17), add PHP min version validation (>= 8.2.0), update extensions (remove json/soap, add session/tokenizer/filter), add pcre.jit setting
- `check_php_settings.php` — Validate PHP version against configurable minimum instead of just displaying it
- `check_database.php` — Refactored to use shared `detectDatabaseProduct()` helper

### Image processing and package versions
- `check_image_processing.php` — New check for GraphicsMagick (>= 1.3) OR ImageMagick (>= 6.0) with version validation
- `check_packages.php` — Display installed version for all packages, add Composer version validation (>= 2.1.0)

### EOL checks
- `check_eol.php` — Check PHP and MariaDB/MySQL against endoflife.date API (FAIL=EOL, WARN=approaching/security-only, OK=maintained)
- `functions.php` — Add helpers: `detectDatabaseProduct()`, `detectPackageVersion()`, `fetchEolCycles()`, `findEolCycle()`, `evaluateEolStatus()`, `checkEolForProduct()`

### New command
- `list.php` — `dep requirements:list` outputs all requirements in a human-readable format for customers/sysadmins

### Wiring and docs
- `autoload.php` / `requirements.php` — Register new tasks in autoload and task chain
- `docs/REQUIREMENTS.md` — Updated documentation with all new checks and configuration options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a requirements listing command and new checks for image processing and end-of-life (EOL) status for PHP and databases
  * Added remote/version-aware detection for system tools, Composer, PHP and database clients

* **Updated Configuration**
  * Framework-aware PHP min version and extensions; updated minimums: MariaDB 10.4.3, MySQL 8.0.17, Composer 2.1.0
  * New toggles and settings for image-processing checks, EOL warnings (default 6 months) and EOL API timeout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->