### PR TITLE
feat: add requirements:health task for service health checks

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -51,6 +51,7 @@ require_once(__DIR__ . '/deployer/requirements/task/check_user.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_env.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_eol.php');
 require_once(__DIR__ . '/deployer/requirements/task/list.php');
+require_once(__DIR__ . '/deployer/requirements/task/health.php');
 
 /*
  * dev

--- a/deployer/requirements/config/set.php
+++ b/deployer/requirements/config/set.php
@@ -107,6 +107,10 @@ set('requirements_composer_min_version', '2.1.0');
 set('requirements_eol_warn_months', 6);
 set('requirements_eol_api_timeout', 5);
 
+// Health check
+set('requirements_check_health_enabled', true);
+set('requirements_health_url', 'http://localhost');
+
 // User / permissions
 set('requirements_user_group', 'www-data');
 set('requirements_deploy_path_permissions', '2770');

--- a/deployer/requirements/config/set.php
+++ b/deployer/requirements/config/set.php
@@ -18,6 +18,7 @@ set('requirements_check_user_enabled', true);
 set('requirements_check_env_enabled', true);
 set('requirements_check_eol_enabled', true);
 set('requirements_check_database_grants_enabled', true);
+set('requirements_check_health_enabled', true);
 
 // Locales
 set('requirements_locales', ['de_DE.utf8', 'en_US.utf8']);
@@ -109,7 +110,6 @@ set('requirements_eol_warn_months', 6);
 set('requirements_eol_api_timeout', 5);
 
 // Health check
-set('requirements_check_health_enabled', true);
 set('requirements_health_url', 'http://localhost');
 
 // User / permissions

--- a/deployer/requirements/functions.php
+++ b/deployer/requirements/functions.php
@@ -369,7 +369,9 @@ function isServiceActive(string ...$names): ?string
                 if ($status === 'active') {
                     return $name;
                 }
-            } elseif (test("pgrep -x $name > /dev/null 2>&1")) {
+            }
+
+            if (test("pgrep -x $name > /dev/null 2>&1")) {
                 return $name;
             }
         } catch (RunException) {

--- a/deployer/requirements/functions.php
+++ b/deployer/requirements/functions.php
@@ -332,6 +332,34 @@ function checkEolForProduct(string $label, string $product, string $cycle, int $
 }
 
 /**
+ * Check if a service is active via systemctl, with pgrep fallback.
+ *
+ * Returns the matched service/process name or null if none found.
+ */
+function isServiceActive(string ...$names): ?string
+{
+    $hasSystemctl = test('command -v systemctl > /dev/null 2>&1');
+
+    foreach ($names as $name) {
+        try {
+            if ($hasSystemctl) {
+                $status = trim(run("systemctl is-active $name 2>/dev/null || true"));
+
+                if ($status === 'active') {
+                    return $name;
+                }
+            } elseif (test("pgrep -x $name > /dev/null 2>&1")) {
+                return $name;
+            }
+        } catch (RunException) {
+            continue;
+        }
+    }
+
+    return null;
+}
+
+/**
  * @return array<string, string>
  */
 function getSharedEnvVars(): array

--- a/deployer/requirements/task/health.php
+++ b/deployer/requirements/task/health.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use Deployer\Exception\RunException;
+
+task('requirements:health', function (): void {
+    set('requirements_rows', []);
+
+    if (!get('requirements_check_health_enabled')) {
+        return;
+    }
+
+    // 1. PHP-FPM
+    try {
+        $phpVersion = trim(run('php -r "echo PHP_MAJOR_VERSION.\'.\'.PHP_MINOR_VERSION;" 2>/dev/null'));
+        $fpmService = isServiceActive("php$phpVersion-fpm", 'php-fpm');
+
+        if ($fpmService !== null) {
+            addRequirementRow('PHP-FPM', REQUIREMENT_OK, "Active ($fpmService)");
+        } else {
+            addRequirementRow('PHP-FPM', REQUIREMENT_FAIL, 'Process not found');
+        }
+    } catch (RunException) {
+        addRequirementRow('PHP-FPM', REQUIREMENT_SKIP, 'Could not determine PHP version');
+    }
+
+    // 2. Webserver
+    $webserver = isServiceActive('nginx', 'apache2', 'httpd');
+
+    if ($webserver !== null) {
+        addRequirementRow('Webserver', REQUIREMENT_OK, "Active ($webserver)");
+    } else {
+        addRequirementRow('Webserver', REQUIREMENT_FAIL, 'No nginx, apache2 or httpd process found');
+    }
+
+    // 3. Database server
+    $db = detectDatabaseProduct();
+    $dbLabel = $db !== null ? $db['label'] : 'Database';
+    $adminCmd = ($db !== null && $db['product'] === 'mariadb') ? 'mariadb-admin' : 'mysqladmin';
+    $dbChecked = false;
+
+    try {
+        run("$adminCmd ping --silent 2>&1 || true");
+        addRequirementRow('Database server', REQUIREMENT_OK, "$dbLabel responding");
+        $dbChecked = true;
+    } catch (RunException) {
+        // Admin tool not available — fall through to process check
+    }
+
+    if (!$dbChecked) {
+        $dbProcess = isServiceActive('mysqld', 'mariadbd');
+
+        if ($dbProcess !== null) {
+            addRequirementRow('Database server', REQUIREMENT_OK, "$dbLabel process running ($dbProcess)");
+        } else {
+            addRequirementRow('Database server', REQUIREMENT_FAIL, 'No mysqld or mariadbd process found');
+        }
+    }
+
+    // 4. HTTP response
+    $url = get('requirements_health_url');
+
+    try {
+        $httpCode = (int) trim(run(
+            sprintf("curl -s -o /dev/null -w '%%{http_code}' --max-time 5 %s 2>/dev/null", escapeshellarg($url))
+        ));
+
+        if ($httpCode >= 200 && $httpCode < 500) {
+            addRequirementRow('HTTP response', REQUIREMENT_OK, "HTTP $httpCode from $url");
+        } elseif ($httpCode === 0) {
+            addRequirementRow('HTTP response', REQUIREMENT_FAIL, "No response from $url (connection refused or timeout)");
+        } else {
+            addRequirementRow('HTTP response', REQUIREMENT_FAIL, "HTTP $httpCode from $url");
+        }
+    } catch (RunException) {
+        addRequirementRow('HTTP response', REQUIREMENT_SKIP, 'curl not available');
+    }
+
+    renderRequirementsTable();
+})->desc('Check service health');

--- a/deployer/requirements/task/health.php
+++ b/deployer/requirements/task/health.php
@@ -16,6 +16,11 @@ task('requirements:health', function (): void {
     // 1. PHP-FPM
     try {
         $phpVersion = trim(run('php -r "echo PHP_MAJOR_VERSION.\'.\'.PHP_MINOR_VERSION;" 2>/dev/null'));
+
+        if (!preg_match('/^\d+\.\d+$/', $phpVersion)) {
+            throw new RunException('php', 1, "Unexpected PHP version output: $phpVersion", '');
+        }
+
         $fpmService = isServiceActive("php$phpVersion-fpm", 'php-fpm');
 
         if ($fpmService !== null) {
@@ -43,7 +48,7 @@ task('requirements:health', function (): void {
     $dbChecked = false;
 
     try {
-        run("$adminCmd ping --silent 2>&1 || true");
+        run("$adminCmd ping --silent 2>/dev/null");
         addRequirementRow('Database server', REQUIREMENT_OK, "$dbLabel responding");
         $dbChecked = true;
     } catch (RunException) {

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -107,6 +107,25 @@ Checks installed PHP and database (MariaDB/MySQL) versions against the [endoflif
 
 The warning threshold is configurable (default: 6 months before EOL).
 
+## Health check
+
+A standalone task that verifies critical services are running on the target host. This is useful as a quick smoke test before or after deployment.
+
+```bash
+$ dep requirements:health [host]
+```
+
+The task checks four categories:
+
+| Check | Method | OK | FAIL |
+|-------|--------|----|------|
+| PHP-FPM | systemctl / pgrep for `php<version>-fpm` | Process active | Process not found |
+| Webserver | systemctl / pgrep for nginx, apache2, httpd | Process active | No process found |
+| Database server | `mysqladmin ping` / `mariadb-admin ping` with process fallback | Responding or process running | No process found |
+| HTTP response | `curl` against configured URL | HTTP 2xx–4xx | HTTP 5xx, timeout, or connection refused |
+
+Service detection uses `systemctl is-active` with a `pgrep` fallback for systems without systemd.
+
 ## Configuration
 
 All settings use the `requirements_` prefix and can be overridden in the consuming project:
@@ -162,6 +181,10 @@ set('requirements_eol_api_timeout', 5);   // API timeout in seconds
 
 // Database grants check
 set('requirements_check_database_grants_enabled', true);
+
+// Health check
+set('requirements_check_health_enabled', true);
+set('requirements_health_url', 'https://example.com');
 ```
 
 ## Extending with custom checks


### PR DESCRIPTION
## Summary

- Add new `requirements:health` Deployer task that checks the availability of critical services on the target host
- Provides quick feedback during deployments to detect infrastructure issues early

## Changes

- `deployer/requirements/task/health.php` - New task checking four service categories:
  1. **PHP-FPM** - Detects version-specific FPM service via systemctl/pgrep
  2. **Webserver** - Checks for nginx, apache2, or httpd
  3. **Database server** - Pings via mysqladmin/mariadb-admin with process fallback
  4. **HTTP response** - Verifies the configured URL returns a non-5xx status
- `deployer/requirements/functions.php` - Add `isServiceActive()` helper (systemctl with pgrep fallback)
- `deployer/requirements/config/set.php` - Add `requirements_check_health_enabled` and `requirements_health_url` config options
- `autoload.php` - Register the new task file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new health-check task (requirements:health) to verify PHP-FPM, webserver, database server and HTTP endpoint status.

* **Chores**
  * Added configuration options to enable/disable health checks and to set the health-check URL.

* **Documentation**
  * Updated Requirements guide with health-check usage, examples and expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->