### PR TITLE
fix: support remote database hosts in health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Read the [documentation](docs/TYPO3.md) for detailed installation instructions a
 ### Standalone Tasks
 - [MS Teams Notification](deployer/notification/task/ms_teams.php)
 - [Database backup](deployer/sync/task/database_backup.php)
-- [Database management](docs/DATABASE.md)
 - [Security check](docs/SECURITY.md)
 - [Development](docs/DEV.md)
 - [Debug helper](docs/DEBUG.md)
+- [Requirements](docs/REQUIREMENTS.md)
 
 
 ## 💛 Acknowledgements

--- a/deployer/requirements/task/health.php
+++ b/deployer/requirements/task/health.php
@@ -45,23 +45,64 @@ task('requirements:health', function (): void {
     $db = detectDatabaseProduct();
     $dbLabel = $db !== null ? $db['label'] : 'Database';
     $adminCmd = ($db !== null && $db['product'] === 'mariadb') ? 'mariadb-admin' : 'mysqladmin';
+    $dbCredentials = resolveDatabaseCredentials();
     $dbChecked = false;
 
-    try {
-        run("$adminCmd ping --silent 2>/dev/null");
-        addRequirementRow('Database server', REQUIREMENT_OK, "$dbLabel responding");
-        $dbChecked = true;
-    } catch (RunException) {
-        // Admin tool not available — fall through to process check
+    // Try mysqladmin ping with credentials when available
+    if ($dbCredentials !== null) {
+        $pingCmd = sprintf(
+            '%s ping --silent -h %s -P %d -u %s --password=%s 2>/dev/null',
+            $adminCmd,
+            escapeshellarg($dbCredentials['host']),
+            $dbCredentials['port'],
+            escapeshellarg($dbCredentials['user']),
+            escapeshellarg($dbCredentials['password'])
+        );
+
+        try {
+            run($pingCmd);
+            $hostInfo = $dbCredentials['host'] === '127.0.0.1' || $dbCredentials['host'] === 'localhost'
+                ? 'local'
+                : $dbCredentials['host'];
+            addRequirementRow('Database server', REQUIREMENT_OK, "$dbLabel responding ($hostInfo)");
+            $dbChecked = true;
+        } catch (RunException) {
+            // Credentials available but ping failed — fall through
+        }
     }
 
+    // Fallback: try mysqladmin ping without credentials (uses ~/.my.cnf or socket)
     if (!$dbChecked) {
-        $dbProcess = isServiceActive('mysqld', 'mariadbd');
+        try {
+            run("$adminCmd ping --silent 2>/dev/null");
+            addRequirementRow('Database server', REQUIREMENT_OK, "$dbLabel responding");
+            $dbChecked = true;
+        } catch (RunException) {
+            // Admin tool not available — fall through to process check
+        }
+    }
 
-        if ($dbProcess !== null) {
-            addRequirementRow('Database server', REQUIREMENT_OK, "$dbLabel process running ($dbProcess)");
+    // Only check for local processes if the database host is local (or unknown)
+    if (!$dbChecked) {
+        $isRemoteDb = $dbCredentials !== null
+            && $dbCredentials['host'] !== '127.0.0.1'
+            && $dbCredentials['host'] !== 'localhost';
+
+        if ($isRemoteDb) {
+            addRequirementRow('Database server', REQUIREMENT_FAIL, sprintf(
+                'Cannot reach %s on %s:%d',
+                $dbLabel,
+                $dbCredentials['host'],
+                $dbCredentials['port']
+            ));
         } else {
-            addRequirementRow('Database server', REQUIREMENT_FAIL, 'No mysqld or mariadbd process found');
+            $dbProcess = isServiceActive('mysqld', 'mariadbd');
+
+            if ($dbProcess !== null) {
+                addRequirementRow('Database server', REQUIREMENT_OK, "$dbLabel process running ($dbProcess)");
+            } else {
+                addRequirementRow('Database server', REQUIREMENT_FAIL, 'No mysqld or mariadbd process found');
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Use `resolveDatabaseCredentials()` in health check to connect to remote database servers via `mysqladmin ping` with host, port, and credentials
- Skip pointless local `pgrep` check when `database_host` points to a remote server
- Show meaningful error messages distinguishing remote connection failures from missing local processes

## Changes

- `deployer/requirements/task/health.php` - Resolve DB credentials and ping remote host; fall back to local process check only for local databases
- `README.md` - Update standalone tasks links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a Standalone Tasks reference link in README.

* **Bug Fixes**
  * Enhanced database health verification with credential-based checking and improved handling for local versus remote database hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->