### PR TITLE
feat: add AVIF, WebP and brotli support checks to requirements

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -44,6 +44,7 @@ require_once(__DIR__ . '/deployer/requirements/task/requirements.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_locales.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_packages.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_image_processing.php');
+require_once(__DIR__ . '/deployer/requirements/task/check_media_support.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_php_extensions.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_php_settings.php');
 require_once(__DIR__ . '/deployer/requirements/task/check_database.php');

--- a/deployer/requirements/config/set.php
+++ b/deployer/requirements/config/set.php
@@ -11,6 +11,7 @@ set('requirements_rows', []);
 set('requirements_check_locales_enabled', true);
 set('requirements_check_packages_enabled', true);
 set('requirements_check_image_processing_enabled', true);
+set('requirements_check_media_support_enabled', true);
 set('requirements_check_php_extensions_enabled', true);
 set('requirements_check_php_settings_enabled', true);
 set('requirements_check_database_enabled', true);

--- a/deployer/requirements/task/check_media_support.php
+++ b/deployer/requirements/task/check_media_support.php
@@ -97,9 +97,9 @@ function checkImageToolFormatSupport(): void
     foreach ($formats as $formatKey => $label) {
         $supported = (bool) preg_match('/^\s*' . $formatKey . '\b/mi', $formatList);
         addRequirementRow(
-            "$toolLabel: $label",
+            "IM/GM: $label",
             $supported ? REQUIREMENT_OK : REQUIREMENT_WARN,
-            $supported ? 'Supported' : 'Format not supported'
+            $supported ? "Supported ($toolLabel)" : "Format not supported ($toolLabel)"
         );
     }
 }

--- a/deployer/requirements/task/check_media_support.php
+++ b/deployer/requirements/task/check_media_support.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Deployer;
+
+use Deployer\Exception\RunException;
+
+task('requirements:check:media_support', function (): void {
+    if (!get('requirements_check_media_support_enabled')) {
+        return;
+    }
+
+    checkGdFormatSupport();
+    checkImageToolFormatSupport();
+    checkBrotliExtension();
+})->hidden();
+
+function checkGdFormatSupport(): void
+{
+    $formats = ['AVIF' => 'AVIF Support', 'WebP' => 'WebP Support'];
+
+    try {
+        $gdJson = run('php -r "echo function_exists(\'gd_info\') ? json_encode(gd_info()) : \'null\';" 2>/dev/null');
+    } catch (RunException) {
+        foreach ($formats as $label => $key) {
+            addRequirementRow("GD: $label Support", REQUIREMENT_SKIP, 'Could not query GD');
+        }
+
+        return;
+    }
+
+    $gdInfo = json_decode($gdJson, true);
+
+    if (!is_array($gdInfo)) {
+        foreach ($formats as $label => $key) {
+            addRequirementRow("GD: $label Support", REQUIREMENT_SKIP, 'GD not available');
+        }
+
+        return;
+    }
+
+    foreach ($formats as $label => $key) {
+        $supported = !empty($gdInfo[$key]);
+        addRequirementRow(
+            "GD: $label Support",
+            $supported ? REQUIREMENT_OK : REQUIREMENT_WARN,
+            $supported ? 'Supported' : 'Not compiled into GD'
+        );
+    }
+}
+
+function checkImageToolFormatSupport(): void
+{
+    $formats = ['AVIF' => 'AVIF', 'WEBP' => 'WebP'];
+    $formatList = null;
+    $toolLabel = null;
+
+    // Try GraphicsMagick first
+    try {
+        $output = run('gm convert -list format 2>/dev/null');
+
+        if ('' !== trim($output)) {
+            $formatList = $output;
+            $toolLabel = 'GraphicsMagick';
+        }
+    } catch (RunException) {
+        // not available
+    }
+
+    // Fallback to ImageMagick
+    if (null === $formatList) {
+        foreach (['magick', 'convert'] as $imCommand) {
+            try {
+                $output = run("$imCommand -list format 2>/dev/null");
+
+                if ('' !== trim($output)) {
+                    $formatList = $output;
+                    $toolLabel = 'ImageMagick';
+
+                    break;
+                }
+            } catch (RunException) {
+                continue;
+            }
+        }
+    }
+
+    if (null === $formatList || null === $toolLabel) {
+        foreach ($formats as $label) {
+            addRequirementRow("IM/GM: $label", REQUIREMENT_SKIP, 'No image processing tool found');
+        }
+
+        return;
+    }
+
+    foreach ($formats as $formatKey => $label) {
+        $supported = (bool) preg_match('/^\s*' . $formatKey . '\b/mi', $formatList);
+        addRequirementRow(
+            "$toolLabel: $label",
+            $supported ? REQUIREMENT_OK : REQUIREMENT_WARN,
+            $supported ? 'Supported' : 'Format not supported'
+        );
+    }
+}
+
+function checkBrotliExtension(): void
+{
+    try {
+        $modules = strtolower(run('php -m 2>/dev/null'));
+    } catch (RunException) {
+        addRequirementRow('PHP ext: brotli', REQUIREMENT_SKIP, 'Could not retrieve PHP modules');
+
+        return;
+    }
+
+    $loaded = in_array('brotli', array_map('trim', explode("\n", $modules)), true);
+    addRequirementRow(
+        'PHP ext: brotli',
+        $loaded ? REQUIREMENT_OK : REQUIREMENT_WARN,
+        $loaded ? 'Loaded' : 'Not loaded'
+    );
+}

--- a/deployer/requirements/task/requirements.php
+++ b/deployer/requirements/task/requirements.php
@@ -8,6 +8,7 @@ task('requirements:check', [
     'requirements:check:locales',
     'requirements:check:packages',
     'requirements:check:image_processing',
+    'requirements:check:media_support',
     'requirements:check:php_extensions',
     'requirements:check:php_settings',
     'requirements:check:database',

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -37,11 +37,11 @@ Checks for modern media format support across the PHP GD library and the install
 
 | Check | Method | OK | WARN | SKIP |
 |-------|--------|----|------|------|
-| GD: AVIF Support | `gd_info()` key `AVIF Support` | Compiled into GD | Not compiled into GD | GD not available |
-| GD: WebP Support | `gd_info()` key `WebP Support` | Compiled into GD | Not compiled into GD | GD not available |
-| IM/GM: AVIF | Format list (`-list format`) | Format supported | Format not supported | No tool found |
-| IM/GM: WebP | Format list (`-list format`) | Format supported | Format not supported | No tool found |
-| PHP ext: brotli | `php -m` | Loaded | Not loaded | — |
+| GD: AVIF Support | `gd_info()` key `AVIF Support` | Supported | Not compiled into GD | GD not available |
+| GD: WebP Support | `gd_info()` key `WebP Support` | Supported | Not compiled into GD | GD not available |
+| IM/GM: AVIF | Format list (`-list format`) | Supported (tool name) | Format not supported (tool name) | No image processing tool found |
+| IM/GM: WebP | Format list (`-list format`) | Supported (tool name) | Format not supported (tool name) | No image processing tool found |
+| PHP ext: brotli | `php -m` | Loaded | Not loaded | Could not retrieve PHP modules |
 
 All checks use WARN (not FAIL) since these features are recommended but not strictly required.
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -21,7 +21,6 @@ $ dep requirements:list [host]
 ## Checks
 
 ### Locales
-
 Verifies that required system locales are available (default: `de_DE.utf8`, `en_US.utf8`).
 
 ### System packages
@@ -31,6 +30,20 @@ Checks for required CLI tools: rsync, curl, ghostscript, git, gzip, mariadb-clie
 ### Image processing
 
 Checks for GraphicsMagick (>= 1.3, recommended) or ImageMagick (>= 6.0) with version validation. Either one is sufficient.
+
+### Media support
+
+Checks for modern media format support across the PHP GD library and the installed image processing tool (GraphicsMagick or ImageMagick):
+
+| Check | Method | OK | WARN | SKIP |
+|-------|--------|----|------|------|
+| GD: AVIF Support | `gd_info()` key `AVIF Support` | Compiled into GD | Not compiled into GD | GD not available |
+| GD: WebP Support | `gd_info()` key `WebP Support` | Compiled into GD | Not compiled into GD | GD not available |
+| IM/GM: AVIF | Format list (`-list format`) | Format supported | Format not supported | No tool found |
+| IM/GM: WebP | Format list (`-list format`) | Format supported | Format not supported | No tool found |
+| PHP ext: brotli | `php -m` | Loaded | Not loaded | — |
+
+All checks use WARN (not FAIL) since these features are recommended but not strictly required.
 
 ### PHP version
 
@@ -157,6 +170,9 @@ set('requirements_packages', [
 // Override database minimum versions
 set('requirements_mariadb_min_version', '10.6.0');
 set('requirements_mysql_min_version', '8.0.30');
+
+// Disable media support checks (AVIF, WebP, brotli)
+set('requirements_check_media_support_enabled', false);
 
 // Override image processing minimum versions
 set('requirements_graphicsmagick_min_version', '1.3.30');


### PR DESCRIPTION
## Summary

- Add new `requirements:check:media_support` task checking AVIF, WebP and brotli support
- Check GD library for AVIF and WebP format support via `gd_info()`
- Check ImageMagick/GraphicsMagick for AVIF and WebP format delegates
- Check brotli PHP extension availability
- All checks use WARN (not FAIL) since these features are recommended but not required

## Changes

- `deployer/requirements/task/check_media_support.php` - New task with three checks (GD formats, IM/GM formats, brotli extension)
- `deployer/requirements/config/set.php` - Add `requirements_check_media_support_enabled` flag
- `deployer/requirements/task/requirements.php` - Register task in orchestration
- `autoload.php` - Add require for new task file
- `docs/REQUIREMENTS.md` - Document media support check section and config option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds media support checks during deployment to detect AVIF/WebP support in image libraries/tools and Brotli PHP extension
  * Checks run as part of the deployment requirements flow and can be disabled via a new configuration flag (enabled by default)
  * Issues WARN-level notices for missing/partial media support

* **Documentation**
  * Updated requirements doc with details and guidance for the new media support checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->