### PR TITLE
fix: remove buffer start/stop task from symfony deployment

### DIFF
--- a/deployer/symfony/task/deploy.php
+++ b/deployer/symfony/task/deploy.php
@@ -52,10 +52,6 @@ task('deploy', [
     // Adjust permissions
     'deploy:writable:chmod',
 
-    // Start buffering http requests. No frontend access possible from now.
-    // Read more on https://github.com/sourcebroker/deployer-extended#buffer-start
-    'buffer:start',
-
     // Truncate caching tables, all cf_* tables
     // Read more on https://github.com/sourcebroker/deployer-extended-database#db-truncate
 //    'db:truncate',
@@ -70,10 +66,6 @@ task('deploy', [
     // Clear frontend http cache.
     // Read more on https://github.com/sourcebroker/deployer-extended#cache-clear-php-http
     'cache:clear_php_http',
-
-    // Frontend access possible again from now
-    // Read more on https://github.com/sourcebroker/deployer-extended#buffer-stop
-    'buffer:stop',
 
     // Standard deployer task.
     'deploy:unlock',


### PR DESCRIPTION
see https://github.com/sourcebroker/deployer-extended/blob/master/CHANGELOG.rst#2000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the deployment process by removing HTTP request buffering steps. This streamlines deployments and may affect timing of requests during the deployment window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->