### PR TITLE
feat: auto-generate TYPO3 encryption key for feature branch instances

### DIFF
--- a/deployer/feature/task/feature_setup.php
+++ b/deployer/feature/task/feature_setup.php
@@ -95,6 +95,7 @@ function renderRemoteTemplates(): void
         'DEPLOYER_CONFIG_FEATURE_NAME' => (string)$feature,
         'DEPLOYER_CONFIG_FEATURE_URL' => get('public_urls')[0],
         'DEPLOYER_CONFIG_FEATURE_PATH' => $featurePath,
+        'DEPLOYER_CONFIG_ENCRYPTION_KEY' => bin2hex(random_bytes(48)),
     ],
         $additionalTemplateVariables)
     ;

--- a/deployer/typo3/example/deployer/templates/.env.dist
+++ b/deployer/typo3/example/deployer/templates/.env.dist
@@ -24,7 +24,7 @@ TYPO3_CONF_VARS__DB__Connections__Default__user={{DEPLOYER_CONFIG_DATABASE_USER}
 TYPO3_CONF_VARS__DB__Connections__Default__dbname={{DEPLOYER_CONFIG_DATABASE_NAME}}
 
 # Secret Encryption Key
-TYPO3_CONF_VARS__SYS__encryptionKey='kjasdf980uhIUOJHgh908DAGUSDHCAG78OSDFHIA<BS98ogu>ypO'
+TYPO3_CONF_VARS__SYS__encryptionKey='{{DEPLOYER_CONFIG_ENCRYPTION_KEY}}'
 
 # TYPO3s compression is unnecessary and error-prone
 TYPO3_CONF_VARS__FE__compressionLevel=0


### PR DESCRIPTION
## Summary

- Replace hardcoded TYPO3 encryption key with auto-generated unique key per feature branch instance
- Each feature branch deployment now receives its own 96-character hex encryption key via `bin2hex(random_bytes(48))`
- Key can be overridden via `DEPLOYER_CONFIG_ENCRYPTION_KEY` environment variable

## Changes

- `deployer/feature/task/feature_setup.php` - Add `DEPLOYER_CONFIG_ENCRYPTION_KEY` to default template arguments
- `deployer/typo3/example/deployer/templates/.env.dist` - Replace static key with `{{DEPLOYER_CONFIG_ENCRYPTION_KEY}}` placeholder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Encryption keys are now automatically generated and configured during each deployment, replacing hardcoded values with dynamic, deployment-specific keys for improved security and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->