### PR TITLE
feat: make Mittwald database host IP resolution configurable

### DIFF
--- a/deployer/feature/config/set.php
+++ b/deployer/feature/config/set.php
@@ -69,3 +69,9 @@ set('feature_stop_disallowed_names', [
  * Database Manager
  */
 set('database_manager_type', 'default');
+
+// Resolve the Mittwald database hostname to its IP and pin it in .env (workaround for DNS
+// flapping of freshly created databases). Disabled by default, since pinning the IP breaks
+// when Mittwald rotates IPs or enforces TLS against the hostname. Enable only if affected by
+// DNS flapping.
+set('mittwald_resolve_host_to_ip', false);

--- a/deployer/feature/task/feature_sync.php
+++ b/deployer/feature/task/feature_sync.php
@@ -75,6 +75,11 @@ function waitForDatabaseHost(): void
  */
 function resolveDatabaseHostToIp(string $hostname): void
 {
+    if (!get('mittwald_resolve_host_to_ip', false)) {
+        debug("Hostname-to-IP resolution disabled, keeping host {$hostname} in .env.");
+        return;
+    }
+
     $resolveCmd = sprintf('echo gethostbyname("%s");', $hostname);
     $ip = trim(run("php -r " . escapeshellarg($resolveCmd)));
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -86,7 +86,14 @@ set('mittwald_project_id', 'your-project-id');
 | `mittwald_database_collation` | `utf8mb4_unicode_ci` | Collation |
 | `mittwald_database_wait` | `30` | Polling interval in seconds |
 | `mittwald_database_retries` | `20` | Max retry attempts |
+| `mittwald_resolve_host_to_ip` | `false` | Pin the resolved IP in `.env` instead of the hostname (see DNS flapping) |
 
 ### DNS flapping
 
-After database creation the DNS entry for the database host (e.g. `mysql-xyz.pg-s-xxx.db.project.host`) may not be resolvable immediately and can flap intermittently. The feature sync task resolves the database hostname to an IP address in the `.env` file to bypass this issue.
+After database creation the DNS entry for the database host (e.g. `mysql-xyz.pg-s-xxx.db.project.host`) may not be resolvable immediately and can flap intermittently.
+
+As a workaround, the database hostname can be resolved to its IP address once (while DNS is known to work) and pinned in the `.env` file, bypassing DNS for all subsequent commands. This is **disabled by default** (`mittwald_resolve_host_to_ip` = `false`), because pinning the IP breaks when Mittwald rotates database IPs or enforces TLS against the hostname. Enable it only for projects actually affected by DNS flapping:
+
+```php
+set('mittwald_resolve_host_to_ip', true);
+```

--- a/src/Database/Manager/MittwaldApi.php
+++ b/src/Database/Manager/MittwaldApi.php
@@ -300,6 +300,11 @@ class MittwaldApi extends AbstractManager implements ManagerInterface
      */
     private function resolveHostnameToIp(string $hostname): string
     {
+        if (!get('mittwald_resolve_host_to_ip', false)) {
+            debug("Hostname-to-IP resolution disabled, using hostname {$hostname}.");
+            return $hostname;
+        }
+
         try {
             $resolveCmd = sprintf('echo gethostbyname("%s");', addslashes($hostname));
             $ip = trim(run("php -r " . escapeshellarg($resolveCmd)));


### PR DESCRIPTION
## Summary

- Add the `mittwald_resolve_host_to_ip` flag to control whether the Mittwald database hostname is resolved to its IP and pinned in `.env`
- Default to `false` so the DNS hostname is kept — pinning the IP breaks when Mittwald rotates database IPs or enforces TLS against the hostname
- TCP reachability checks still run; only the IP pinning is now opt-in

## Background

The hostname-to-IP resolution was a workaround for DNS flapping of freshly created Mittwald databases, but it ran unconditionally in two places and now causes problems on Mittwald infrastructure.

## Changes

- `deployer/feature/config/set.php` - Add `mittwald_resolve_host_to_ip` flag (default `false`)
- `src/Database/Manager/MittwaldApi.php` - Guard `resolveHostnameToIp()` (setup path)
- `deployer/feature/task/feature_sync.php` - Guard `resolveDatabaseHostToIp()` (sync path)
- `docs/DATABASE.md` - Document the flag and updated DNS flapping behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional configuration option for Mittwald API database management. When enabled, it controls whether database hostnames are resolved and pinned to IP addresses. This feature is disabled by default.

* **Documentation**
  * Expanded the database documentation with comprehensive information about DNS behavior, potential issues with IP rotation, and clear guidance on when and how to enable the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->