### PR TITLE
chore(ci): use reusable github actions workflows

### DIFF
--- a/.github/workflows/cgl.yml
+++ b/.github/workflows/cgl.yml
@@ -6,54 +6,6 @@ on:
 
 jobs:
   cgl:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      # Prepare environment
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          # @todo Use PHP 8.4 once PHP-CS-Fixer supports PHP 8.4
-          php-version: 8.3
-          tools: composer:v2, composer-require-checker, composer-unused, cs2pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Validation
-      - name: Validate composer.json
-        run: composer validate
-
-      # Install dependencies
-      - name: Add required packages
-        run: composer require composer/composer:"^2.2"
-
-      # Check Composer dependencies
-      - name: Check dependencies
-        run: composer-require-checker check
-      - name: Reset composer.json
-        run: git checkout composer.json
-      - name: Re-install Composer dependencies
-        uses: ramsey/composer-install@4.0.0
-      - name: Check for unused dependencies
-        run: composer-unused --excludePackage=deployer/deployer --excludePackage=sourcebroker/deployer-extended
-
-      # Linting
-      - name: Update composer.lock
-        run: composer update --lock
-      - name: Lint composer.json
-        run: composer lint:composer
-      - name: Lint Editorconfig
-        run: composer lint:editorconfig
-      - name: Lint PHP
-        run: composer lint:php -- --format checkstyle | cs2pr
-
-      # SCA
-      - name: SCA PHP
-        run: composer sca:php -- --error-format github
-
-      # Migration
-      - name: Run Rector migration
-        run: composer migration:rector -- --dry-run
+    uses: konradmichalik/reusable-github-actions/.github/workflows/cgl.yml@main
+    with:
+      php-version: '8.3'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,27 +6,5 @@ on:
       - '*'
 
 jobs:
-  # Job: Create release
   release:
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    outputs:
-      release-notes-url: ${{ steps.create-release.outputs.url }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      # Check if tag is valid
-      - name: Check tag
-        run: |
-          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
-            exit 1
-          fi
-
-      # Create release
-      - name: Create release
-        id: create-release
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
+    uses: konradmichalik/reusable-github-actions/.github/workflows/release.yml@main

--- a/composer-unused.php
+++ b/composer-unused.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use ComposerUnused\ComposerUnused\Configuration\Configuration;
+use ComposerUnused\ComposerUnused\Configuration\NamedFilter;
+
+return static function (Configuration $config): Configuration {
+    // These packages are consumed via Deployer's recipe loading mechanism,
+    // not through PHP `use`/autoload, so composer-unused cannot detect them.
+    return $config
+        ->addNamedFilter(NamedFilter::fromString('deployer/deployer'))
+        ->addNamedFilter(NamedFilter::fromString('sourcebroker/deployer-extended'));
+};


### PR DESCRIPTION
## Summary

- Replace the inline CGL and Release workflows with the shared reusable workflows from `konradmichalik/reusable-github-actions`
- Move the `composer-unused` package exclusions out of the workflow into a repo-local config file, so the generic reusable CGL workflow works unchanged

## Changes

- `.github/workflows/cgl.yml` — call reusable `cgl.yml@main` with `php-version: '8.3'`
- `.github/workflows/release.yml` — call reusable `release.yml@main`
- `composer-unused.php` — ignore `deployer/deployer` and `sourcebroker/deployer-extended` via `NamedFilter` (these are consumed through Deployer's recipe loader, not PHP autoload)

## Notes

- Verified locally: both workflows parse as valid YAML, `composer-unused.php` lints clean, and a bare `composer-unused` run (phar 0.9.6, the version CI installs) reports `0 unused, 2 ignored` with exit 0 — the config replaces the former `--excludePackage` flags exactly.
- The previous `composer update --lock` step is intentionally dropped (not present in the reusable workflow; not required by composer-normalize / PHP-CS-Fixer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored CI/CD pipeline to use centralized reusable GitHub Actions workflows for improved maintainability and consistency
  * Updated build configuration to enhance dependency analysis during the build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->