### PR TITLE
fix(feature): build url shortener feature url with trailing slash

### DIFF
--- a/deployer/feature/task/url_shortener.php
+++ b/deployer/feature/task/url_shortener.php
@@ -4,8 +4,12 @@ namespace Deployer;
 
 tasK('feature:urlshortener', function () {
 
-    if (!input()->getOption('feature')) return;
-    if (!isUrlShortener()) return;
+    if (!input()->getOption('feature')) {
+        return;
+    }
+    if (!isUrlShortener()) {
+        return;
+    }
 
     $symlinkDir = get('deploy_path') . "/current/" . get('web_path');
 
@@ -35,7 +39,9 @@ function isUrlShortener(): bool
  */
 function initUrlShortener(?string $feature = null): void
 {
-    if (!isUrlShortener()) return;
+    if (!isUrlShortener()) {
+        return;
+    }
 
     debug('Adjust host configuration because of url shortener function');
     set('deploy_path_url_shortener', get('deploy_path'));
@@ -43,7 +49,7 @@ function initUrlShortener(?string $feature = null): void
 
     $publicUrls = [];
     foreach (get('public_urls') as $publicUrl) {
-        $publicUrls[] = $publicUrl . $feature;
+        $publicUrls[] = rtrim($publicUrl, '/') . '/' . $feature . '/';
     }
     set('public_urls', $publicUrls);
 }


### PR DESCRIPTION
## Summary

- Fix `initUrlShortener()` so the generated feature URL is built slash-robust and always ends with `/`, independent of whether `public_urls` is configured with or without a trailing slash
- Previously the branch was appended directly (`"https://host/" . "BRANCH"` → `https://host/BRANCH`, no trailing slash), corrupting `DEPLOYER_CONFIG_FEATURE_URL` (TYPO3_BASEURL) in consumer projects
- That broke the TYPO3 site `base` and all values derived from it via string concatenation (e.g. `%env(TYPO3_BASEURL)%sitemap.xml`, errorContentSource) → broken absolute URLs, breadcrumbs, and 504 hangs on error

## Changes

- `deployer/feature/task/url_shortener.php` — `initUrlShortener()` now builds the URL as `rtrim($publicUrl, '/') . '/' . $feature . '/'`

## Verification

For branch `FOO-123`, `DEPLOYER_CONFIG_FEATURE_URL` resolves to exactly `https://stage.example.de/FOO-123/` for both input variants:

| `public_urls` input | Result |
|---|---|
| `https://stage.example.de/` | `https://stage.example.de/FOO-123/` ✓ |
| `https://stage.example.de` (no trailing slash) | `https://stage.example.de/FOO-123/` ✓ |

Other concatenation sites in the package (`deploy_path`, `dev/config/set.php`, `feature_scheduler.php`) join with `feature_url_shortener_path`, which ends in `/` by default — no double slashes introduced. No automated test framework exists in this Deployer recipe package, so verification was done manually.

## ⚠️ Re-init required

Feature config files are generated only **once** (`once`-generated `feature_templates`). **Existing feature instances must re-init** (re-run `feature:setup` / regenerate their generated config) for the corrected URL to take effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL shortening to handle trailing slashes more consistently across shortened URLs.

* **Refactor**
  * Optimized internal control flow structure for deployment task gating logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->