### PR TITLE
fix: ensure prod database backup runs and can be disabled

### DIFF
--- a/deployer/symfony/config/set.php
+++ b/deployer/symfony/config/set.php
@@ -84,4 +84,4 @@ set('feature_index_app_type', 'symfony');
 // Prod deployment, add backup
 task('database:backup')->select('prod');
 before('deploy:database:update', 'database:backup');
-set('sync_database_backup_config', __DIR__ . '/.deployment/db-sync-tool/backup-prod.yaml');
+set('sync_database_backup_config', './.deployment/db-sync-tool/backup-prod.yaml');

--- a/deployer/sync/config/set.php
+++ b/deployer/sync/config/set.php
@@ -2,4 +2,5 @@
 
 namespace Deployer;
 
+set('db_sync_tool', 'db_sync_tool'); # set to false, to disable db backup
 #set('sync_database_backup_config', null);

--- a/deployer/sync/task/database_backup.php
+++ b/deployer/sync/task/database_backup.php
@@ -6,11 +6,16 @@ task('database:backup', function () {
 
     $optionalVerbose = isVerbose() ? '-v' : '';
 
+    if (false === get('db_sync_tool')) {
+        debug('Skipping database backup, db_sync_tool was disabled');
+        return;
+    }
+
     if (commandExistLocally("{{db_sync_tool}}")) {
         info('Generating a database backup');
         runLocally("{{db_sync_tool}} -f {{sync_database_backup_config}} --use-rsync -y $optionalVerbose");
     } else {
-        debug("Skipping database sync, {{db_sync_tool}} not available");
+        debug("Skipping database backup, {{db_sync_tool}} not available");
     }
 
 })

--- a/deployer/typo3/task/deploy_database.php
+++ b/deployer/typo3/task/deploy_database.php
@@ -16,7 +16,7 @@ task('deploy:database:update', function () {
  */
 task('database:backup')->select('prod');
 before('deploy:database:update', 'database:backup');
-set('sync_database_backup_config', __DIR__ . '/.deployment/db-sync-tool/backup-prod.yaml');
+set('sync_database_backup_config', './.deployment/db-sync-tool/backup-prod.yaml');
 
 
 function getDatabasePasswordForTypo3(): string|bool


### PR DESCRIPTION
## Summary

- Fix the production `database:backup` task silently failing (or never running) on Symfony/TYPO3 deployments
- Make `db_sync_tool` available wherever the backup task runs, and honor disabling it
- Point the backup config at the project root instead of the vendor directory

## Root cause

The `database:backup` task is wired into prod deploys by the Symfony/TYPO3 presets, but the variables it relies on were defined only in the feature-deployment config group, which those presets never load. Combined with a missing disable-guard and a vendor-relative config path, the task could not locate its config and could not be turned off.

## Changes

- `deployer/sync/config/set.php` — define `db_sync_tool` default in the sync config group, the file that belongs to the `database:backup` task, so it is defined on every deploy that can run the task
- `deployer/sync/task/database_backup.php` — add the `db_sync_tool === false` disable guard (mirroring `feature:sync`) so backups can be turned off; correct the fallback debug message
- `deployer/symfony/config/set.php` — resolve `sync_database_backup_config` project-relative (`./.deployment/...`) instead of `__DIR__`, which pointed into `vendor/` and never existed
- `deployer/typo3/task/deploy_database.php` — same project-relative path fix

## Test plan

- [ ] Run a prod deploy with a valid `./.deployment/db-sync-tool/backup-prod.yaml` and confirm the backup is generated
- [ ] Set `db_sync_tool` to `false` and confirm the backup step is skipped without error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
* Updated database backup configuration file paths from absolute to relative paths across all deployment environments for better portability and flexibility
* Introduced new configuration option that allows database backups to be selectively enabled or disabled based on specific deployment needs
* Enhanced the database backup task to automatically check and respect the new configuration setting before executing backups
* Improved overall consistency in how database backup configurations are handled across different deployment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->