### PR TITLE
chore(deps): support deployer v8

### DIFF
--- a/composer-unused.php
+++ b/composer-unused.php
@@ -6,9 +6,8 @@ use ComposerUnused\ComposerUnused\Configuration\Configuration;
 use ComposerUnused\ComposerUnused\Configuration\NamedFilter;
 
 return static function (Configuration $config): Configuration {
-    // These packages are consumed via Deployer's recipe loading mechanism,
-    // not through PHP `use`/autoload, so composer-unused cannot detect them.
+    // deployer-extended is consumed via Deployer's recipe loading mechanism,
+    // not through PHP `use`/autoload, so composer-unused cannot detect it.
     return $config
-        ->addNamedFilter(NamedFilter::fromString('deployer/deployer'))
         ->addNamedFilter(NamedFilter::fromString('sourcebroker/deployer-extended'));
 };

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
 		"php": "^8.1",
 		"ext-json": "*",
 		"ext-pcre": "*",
-		"deployer/deployer": "^7.0",
-		"sourcebroker/deployer-extended": "^24.0",
+		"deployer/deployer": "^7.0 || ^8.0",
+		"sourcebroker/deployer-extended": "^24.2",
 		"sourcebroker/deployer-loader": "^5.0"
 	},
 	"require-dev": {

--- a/src/Utility/VarUtility.php
+++ b/src/Utility/VarUtility.php
@@ -21,7 +21,7 @@ class VarUtility
     {
         $var = ucfirst($var);
         $type = get('app_type');
-        $functionName = "\Deployer\getDatabase{$var}For" . ucfirst($type);
+        $functionName = "\Deployer\getDatabase{$var}For" . ucfirst((string) $type);
         require_once(__DIR__ . "/../../deployer/$type/task/deploy_database.php");
         if (function_exists($functionName)) {
             return call_user_func($functionName);


### PR DESCRIPTION
## Summary

- Widen the `deployer/deployer` constraint to `^7.0 || ^8.0` and bump `sourcebroker/deployer-extended` to `^24.2` (the first release that allows Deployer v8).
- Dual support, no breaking change: on PHP 8.1/8.2 Composer resolves Deployer v7, on PHP 8.3+ it can resolve v8. `php` stays `^8.1`.

## Background

`sourcebroker/deployer-extended` was the sole blocker for Deployer v8 (it pinned `^7.0.0`). Release **24.2.0** now allows `^7.0.0 || ^8.0.0` and has no hard dependency on the v7-pinned companion packages, so the graph resolves cleanly.

## Verification

- `composer update -W --dry-run` (PHP 8.5) resolves the v8 path: `deployer/deployer v8.0.5`, `maml/maml v3.2.0`, `sourcebroker/deployer-extended 24.2.0`, `symfony/console v8.1.1` — exit 0.
- `composer.json` is already normalized; the recipe code uses only Deployer APIs that are unchanged in v8 (verified earlier: `parse`, `run`, `currentHost`, `Httpie`, `GroupTask`, `recipe/common.php` all present in v8).
- CGL CI runs on PHP 8.3, so it exercises the v8 resolution path.

## Changes

- `composer.json` — `deployer/deployer: ^7.0 || ^8.0`, `sourcebroker/deployer-extended: ^24.2`

Refs: sourcebroker/deployer-extended#22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency compatibility to support newer Composer versions and a more recent deployment helper package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->